### PR TITLE
Update github-pages.yml

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
 


### PR DESCRIPTION
At the start of 2025, Github upgraded some of the Github Actions Artifacts to v4. Our workflow's publish.yml file's last few lines used to be this - but the site could not be found (404 error):