### PR TITLE
Fix ghcr.io Docker push auth

### DIFF
--- a/.github/workflows/docker-build-multiarch.yml
+++ b/.github/workflows/docker-build-multiarch.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -28,7 +31,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v4


### PR DESCRIPTION
## Summary

- `secrets.TOKEN` was causing `denied: denied` on ghcr.io login
- Switch to `secrets.GITHUB_TOKEN` (built-in, always available) with explicit `packages: write` permission on the job
- No manual secret management needed

## Test plan
- [x] Merge and verify the Docker build workflow completes without auth error on next push to main

🤖 Generated with [Claude Code](https://claude.ai/claude-code)