### PR TITLE
Increase max drive count from 16 to 24

### DIFF
--- a/src/app/ServerRack.tsx
+++ b/src/app/ServerRack.tsx
@@ -18,7 +18,7 @@ interface ServerRackProps {
 const ServerRack: React.FC<ServerRackProps> = ({ 
   drives, 
   onDriveClick, 
-  maxSlots = 16 
+  maxSlots = 24
 }) => {
   // Calculate how many rows and columns we need
   const drivesPerRow = 4;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -169,7 +169,7 @@ const RAIDCalculator = () => {
   // Add a drive to the active configuration
   const addDrive = (size: number) => {
     const activeConfig = configs[activeConfigIndex];
-    if (activeConfig.selectedDrives.length < 16) {
+    if (activeConfig.selectedDrives.length < 24) {
       const updatedDrives = [...activeConfig.selectedDrives, { id: Date.now(), size }];
       updateConfig(activeConfigIndex, { selectedDrives: updatedDrives });
     }


### PR DESCRIPTION
## Summary

Closes #27

- Raises drive cap from 16 → 24 in `addDrive` guard (`page.tsx`)
- Updates `ServerRack` default `maxSlots` from 16 → 24 — the rack already uses a dynamic 4-per-row grid so the 2 extra rows render automatically

## Test plan
- [x] `npm test` — 28/28 pass
- [x] `npm run build` — clean build
- [x] Verify rack shows 6 rows (24 slots) and accepts up to 24 drives

🤖 Generated with [Claude Code](https://claude.ai/claude-code)