### PR TITLE
Fix RAID calc correctness for mixed-drive sizes and min-drive thresholds

### DIFF
--- a/src/app/raidCalc.test.ts
+++ b/src/app/raidCalc.test.ts
@@ -5,8 +5,11 @@ import {
   calcSingleParity,
   calcDoubleParity,
   calcTripleParity,
+  calcSHR,
+  calcSHR2,
   calcRaid10,
   calcUnraidParity1,
+  calcUnraidParity2,
   calcUnraidParity3,
   calcSnapRaid,
   calcVdevRaid,
@@ -56,11 +59,11 @@ describe('calcMirror (RAID 1)', () => {
   });
 });
 
-describe('calcSingleParity (RAID 5 / RAID-Z1 / SHR)', () => {
+describe('calcSingleParity (RAID 5 / RAID-Z1)', () => {
   // Browser-validated: 6×8TB RAID-Z1 → usable=40, efficiency=83.3%
-  it('available = total minus largest drive', () => {
+  it('equal drives: available = (N-1) × driveSize', () => {
     const r = calcSingleParity(drives6x8);
-    expect(r.available).toBe(40); // 48 - 8
+    expect(r.available).toBe(40); // 5 × 8
     expect(r.protection).toBe(8);
     expect(r.reliability).toBe(70);
   });
@@ -71,16 +74,24 @@ describe('calcSingleParity (RAID 5 / RAID-Z1 / SHR)', () => {
     expect(r.writeSpeed).toBeCloseTo(140 * 5 * 0.7); // 490
   });
 
+  it('mixed drives: available = (N-1) × smallest drive', () => {
+    // [8,8,8,8,4,4] — Synology-validated: available ≈ 20 TB decimal
+    const mixed: Drive[] = [
+      {id:0,size:8},{id:1,size:8},{id:2,size:8},{id:3,size:8},{id:4,size:4},{id:5,size:4}
+    ];
+    expect(calcSingleParity(mixed).available).toBe(20); // 5 × 4
+  });
+
   it('returns 0 usable with only 1 drive', () => {
     expect(calcSingleParity(makeDrives(1, 8)).available).toBe(0);
   });
 });
 
-describe('calcDoubleParity (RAID 6 / RAID-Z2 / SHR-2)', () => {
+describe('calcDoubleParity (RAID 6 / RAID-Z2)', () => {
   // Browser-validated: 6×8TB RAID-Z2 → usable=32, efficiency=66.7%
-  it('available = total minus 2 × largest drive', () => {
+  it('equal drives: available = (N-2) × driveSize', () => {
     const r = calcDoubleParity(drives6x8);
-    expect(r.available).toBe(32); // 48 - 16
+    expect(r.available).toBe(32); // 4 × 8
     expect(r.protection).toBe(16);
     expect(r.reliability).toBe(85);
   });
@@ -91,15 +102,24 @@ describe('calcDoubleParity (RAID 6 / RAID-Z2 / SHR-2)', () => {
     expect(r.writeSpeed).toBeCloseTo(140 * 4 * 0.6); // 336
   });
 
-  it('returns 0 usable with 2 or fewer drives', () => {
+  it('mixed drives: available = (N-2) × smallest drive', () => {
+    // [8,8,8,8,4,4] — Synology-validated: available ≈ 16 TB decimal
+    const mixed: Drive[] = [
+      {id:0,size:8},{id:1,size:8},{id:2,size:8},{id:3,size:8},{id:4,size:4},{id:5,size:4}
+    ];
+    expect(calcDoubleParity(mixed).available).toBe(16); // 4 × 4
+  });
+
+  it('returns 0 usable with 3 or fewer drives (minimum 4 for RAID 6/Z2)', () => {
     expect(calcDoubleParity(makeDrives(2, 8)).available).toBe(0);
+    expect(calcDoubleParity(makeDrives(3, 8)).available).toBe(0);
   });
 });
 
 describe('calcTripleParity (RAID-Z3)', () => {
-  it('available = total minus 3 × largest drive', () => {
+  it('equal drives: available = (N-3) × driveSize', () => {
     const r = calcTripleParity(drives6x8);
-    expect(r.available).toBe(24); // 48 - 24
+    expect(r.available).toBe(24); // 3 × 8
     expect(r.protection).toBe(24);
     expect(r.reliability).toBe(95);
   });
@@ -110,8 +130,54 @@ describe('calcTripleParity (RAID-Z3)', () => {
     expect(r.writeSpeed).toBeCloseTo(140 * 3 * 0.5); // 210
   });
 
-  it('returns 0 usable with 3 or fewer drives', () => {
+  it('mixed drives: available = (N-3) × smallest drive', () => {
+    const mixed: Drive[] = [
+      {id:0,size:8},{id:1,size:8},{id:2,size:8},{id:3,size:4},{id:4,size:4},{id:5,size:4}
+    ];
+    expect(calcTripleParity(mixed).available).toBe(12); // 3 × 4
+  });
+
+  it('returns 0 usable with 4 or fewer drives (minimum 5 for RAID-Z3)', () => {
     expect(calcTripleParity(makeDrives(3, 8)).available).toBe(0);
+    expect(calcTripleParity(makeDrives(4, 8)).available).toBe(0);
+  });
+});
+
+describe('calcSHR (Synology Hybrid RAID single-parity)', () => {
+  it('equal drives: same as RAID 5', () => {
+    const r = calcSHR(drives6x8);
+    expect(r.available).toBe(40); // t - max = 48 - 8
+    expect(r.protection).toBe(8);
+    expect(r.reliability).toBe(70);
+  });
+
+  it('mixed drives: available = total minus largest drive', () => {
+    // [8,8,8,8,4,4] — Synology-validated: available ≈ 32 TB decimal
+    const mixed: Drive[] = [
+      {id:0,size:8},{id:1,size:8},{id:2,size:8},{id:3,size:8},{id:4,size:4},{id:5,size:4}
+    ];
+    expect(calcSHR(mixed).available).toBe(32); // 40 - 8
+  });
+});
+
+describe('calcSHR2 (Synology Hybrid RAID dual-parity)', () => {
+  it('equal drives: same as RAID 6', () => {
+    const r = calcSHR2(drives6x8);
+    expect(r.available).toBe(32); // t - 2*max = 48 - 16
+    expect(r.protection).toBe(16);
+    expect(r.reliability).toBe(85);
+  });
+
+  it('mixed drives: available = total minus 2 × largest drive', () => {
+    // [8,8,8,8,4,4] — Synology-validated: available ≈ 24 TB decimal
+    const mixed: Drive[] = [
+      {id:0,size:8},{id:1,size:8},{id:2,size:8},{id:3,size:8},{id:4,size:4},{id:5,size:4}
+    ];
+    expect(calcSHR2(mixed).available).toBe(24); // 40 - 16
+  });
+
+  it('returns 0 usable with 3 or fewer drives', () => {
+    expect(calcSHR2(makeDrives(3, 8)).available).toBe(0);
   });
 });
 
@@ -143,14 +209,51 @@ describe('calcUnraidParity1', () => {
   });
 });
 
+describe('calcUnraidParity2', () => {
+  it('same capacity as double-parity for equal drives, Unraid speed profile', () => {
+    const r = calcUnraidParity2(drives6x8);
+    expect(r.available).toBe(32); // 4 data × 8 TB
+    expect(r.protection).toBe(16);
+    expect(r.reliability).toBe(85);
+    expect(r.readSpeed).toBeCloseTo(150 * Math.min(1.5, 6 * 0.2));
+    expect(r.writeSpeed).toBeCloseTo(140 * 0.5);
+  });
+
+  it('mixed sizes: 2 largest drives are parity', () => {
+    const mixed: Drive[] = [
+      { id: 0, size: 10 }, { id: 1, size: 8 }, { id: 2, size: 6 }, { id: 3, size: 4 },
+    ];
+    const r = calcUnraidParity2(mixed);
+    expect(r.available).toBe(10); // 6+4
+    expect(r.protection).toBe(18); // 10+8
+  });
+
+  it('returns 0 usable with 2 or fewer drives', () => {
+    expect(calcUnraidParity2(makeDrives(2, 8)).available).toBe(0);
+  });
+});
+
 describe('calcUnraidParity3', () => {
-  it('same capacity as triple-parity but Unraid speeds', () => {
+  it('same capacity as triple-parity for equal drives, Unraid speeds', () => {
     const r = calcUnraidParity3(drives6x8);
-    expect(r.available).toBe(24);
+    expect(r.available).toBe(24); // 3 data × 8 TB
     expect(r.protection).toBe(24);
     expect(r.reliability).toBe(95);
     expect(r.readSpeed).toBeCloseTo(150 * Math.min(1.5, 6 * 0.2));
     expect(r.writeSpeed).toBeCloseTo(140 * 0.35);
+  });
+
+  it('mixed sizes: 3 largest drives are parity', () => {
+    const mixed: Drive[] = [
+      { id: 0, size: 10 }, { id: 1, size: 8 }, { id: 2, size: 6 }, { id: 3, size: 4 },
+    ];
+    const r = calcUnraidParity3(mixed);
+    expect(r.available).toBe(4); // only 4 TB drive is data
+    expect(r.protection).toBe(24); // 10+8+6
+  });
+
+  it('returns 0 usable with 3 or fewer drives', () => {
+    expect(calcUnraidParity3(makeDrives(3, 8)).available).toBe(0);
   });
 });
 
@@ -216,13 +319,29 @@ describe('calcConfigRaid dispatcher', () => {
     expect(calcConfigRaid('Mirror', drives6x8).available).toBe(8);
     expect(calcConfigRaid('RAID 5', drives6x8).available).toBe(40);
     expect(calcConfigRaid('RAID-Z1', drives6x8).available).toBe(40);
-    expect(calcConfigRaid('SHR', drives6x8).available).toBe(40);
+    expect(calcConfigRaid('SHR', drives6x8).available).toBe(40);   // equal drives → same as RAID 5
     expect(calcConfigRaid('RAID 6', drives6x8).available).toBe(32);
     expect(calcConfigRaid('RAID-Z2', drives6x8).available).toBe(32);
-    expect(calcConfigRaid('SHR-2', drives6x8).available).toBe(32);
+    expect(calcConfigRaid('SHR-2', drives6x8).available).toBe(32); // equal drives → same as RAID 6
     expect(calcConfigRaid('Parity 2', drives6x8).available).toBe(32);
     expect(calcConfigRaid('RAID-Z3', drives6x8).available).toBe(24);
     expect(calcConfigRaid('RAID 10', drives6x8).available).toBe(24);
+  });
+
+  it('SHR and RAID 5 differ on mixed drives — Synology-validated', () => {
+    const mixed: Drive[] = [
+      {id:0,size:8},{id:1,size:8},{id:2,size:8},{id:3,size:8},{id:4,size:4},{id:5,size:4}
+    ];
+    expect(calcConfigRaid('SHR', mixed).available).toBe(32);   // t - max = 40 - 8
+    expect(calcConfigRaid('RAID 5', mixed).available).toBe(20); // (N-1) × min = 5 × 4
+  });
+
+  it('SHR-2 and RAID 6 differ on mixed drives — Synology-validated', () => {
+    const mixed: Drive[] = [
+      {id:0,size:8},{id:1,size:8},{id:2,size:8},{id:3,size:8},{id:4,size:4},{id:5,size:4}
+    ];
+    expect(calcConfigRaid('SHR-2', mixed).available).toBe(24);  // t - 2*max = 40 - 16
+    expect(calcConfigRaid('RAID 6', mixed).available).toBe(16); // (N-2) × min = 4 × 4
   });
 
   it('Parity 1 (Unraid) uses Unraid speed profile, not Z1 profile', () => {

--- a/src/app/raidCalc.ts
+++ b/src/app/raidCalc.ts
@@ -22,6 +22,10 @@ function maxDrive(drives: Drive[]): number {
   return Math.max(...drives.map(d => d.size));
 }
 
+function minDrive(drives: Drive[]): number {
+  return Math.min(...drives.map(d => d.size));
+}
+
 export function calcStriped(drives: Drive[]): RaidStats {
   const t = sumDrives(drives);
   return {
@@ -45,8 +49,47 @@ export function calcMirror(drives: Drive[]): RaidStats {
   };
 }
 
-// RAID 5 / RAID-Z1 / SHR — 1 parity drive (largest)
+// RAID 5 / RAID-Z1 — 1 distributed parity stripe; usable = (N-1) × smallest drive
 export function calcSingleParity(drives: Drive[]): RaidStats {
+  const t = sumDrives(drives);
+  const available = drives.length > 1 ? (drives.length - 1) * minDrive(drives) : 0;
+  return {
+    available,
+    protection: t - available,
+    readSpeed: BASE_READ * (drives.length - 1) * 0.8,
+    writeSpeed: BASE_WRITE * (drives.length - 1) * 0.7,
+    reliability: 70,
+  };
+}
+
+// RAID 6 / RAID-Z2 — 2 distributed parity stripes; usable = (N-2) × smallest drive, minimum 4 drives
+export function calcDoubleParity(drives: Drive[]): RaidStats {
+  const t = sumDrives(drives);
+  const available = drives.length > 3 ? (drives.length - 2) * minDrive(drives) : 0;
+  return {
+    available,
+    protection: t - available,
+    readSpeed: BASE_READ * (drives.length - 2) * 0.8,
+    writeSpeed: BASE_WRITE * (drives.length - 2) * 0.6,
+    reliability: 85,
+  };
+}
+
+// RAID-Z3 — 3 distributed parity stripes; usable = (N-3) × smallest drive, minimum 5 drives
+export function calcTripleParity(drives: Drive[]): RaidStats {
+  const t = sumDrives(drives);
+  const available = drives.length > 4 ? (drives.length - 3) * minDrive(drives) : 0;
+  return {
+    available,
+    protection: t - available,
+    readSpeed: BASE_READ * (drives.length - 3) * 0.8,
+    writeSpeed: BASE_WRITE * (drives.length - 3) * 0.5,
+    reliability: 95,
+  };
+}
+
+// SHR (Synology Hybrid RAID) — largest drive is parity; smaller drives use remaining space fully
+export function calcSHR(drives: Drive[]): RaidStats {
   const t = sumDrives(drives);
   const available = drives.length > 1 ? t - maxDrive(drives) : 0;
   return {
@@ -58,29 +101,16 @@ export function calcSingleParity(drives: Drive[]): RaidStats {
   };
 }
 
-// RAID 6 / RAID-Z2 / SHR-2 / Unraid Parity 2 — 2 parity drives
-export function calcDoubleParity(drives: Drive[]): RaidStats {
+// SHR-2 (Synology Hybrid RAID 2) — 2 largest drives are parity overhead; minimum 4 drives
+export function calcSHR2(drives: Drive[]): RaidStats {
   const t = sumDrives(drives);
-  const available = drives.length > 2 ? t - 2 * maxDrive(drives) : 0;
+  const available = drives.length > 3 ? t - 2 * maxDrive(drives) : 0;
   return {
     available,
     protection: t - available,
     readSpeed: BASE_READ * (drives.length - 2) * 0.8,
     writeSpeed: BASE_WRITE * (drives.length - 2) * 0.6,
     reliability: 85,
-  };
-}
-
-// RAID-Z3 — 3 parity drives
-export function calcTripleParity(drives: Drive[]): RaidStats {
-  const t = sumDrives(drives);
-  const available = drives.length > 3 ? t - 3 * maxDrive(drives) : 0;
-  return {
-    available,
-    protection: t - available,
-    readSpeed: BASE_READ * (drives.length - 3) * 0.8,
-    writeSpeed: BASE_WRITE * (drives.length - 3) * 0.5,
-    reliability: 95,
   };
 }
 
@@ -109,10 +139,27 @@ export function calcUnraidParity1(drives: Drive[]): RaidStats {
   };
 }
 
-// Unraid Parity 3 — lower sequential perf than Z3
+// Unraid Parity 2 — 2 largest drives are parity; data drives keep full capacity
+export function calcUnraidParity2(drives: Drive[]): RaidStats {
+  const t = sumDrives(drives);
+  if (drives.length <= 2) return { available: 0, protection: t, readSpeed: 0, writeSpeed: 0, reliability: 0 };
+  const sorted = [...drives].sort((a, b) => b.size - a.size);
+  const available = sorted.slice(2).reduce((s, d) => s + d.size, 0);
+  return {
+    available,
+    protection: t - available,
+    readSpeed: BASE_READ * Math.min(1.5, drives.length * 0.2),
+    writeSpeed: BASE_WRITE * 0.5,
+    reliability: 85,
+  };
+}
+
+// Unraid Parity 3 — 3 largest drives are parity; data drives keep full capacity
 export function calcUnraidParity3(drives: Drive[]): RaidStats {
   const t = sumDrives(drives);
-  const available = drives.length > 3 ? t - 3 * maxDrive(drives) : 0;
+  if (drives.length <= 3) return { available: 0, protection: t, readSpeed: 0, writeSpeed: 0, reliability: 0 };
+  const sorted = [...drives].sort((a, b) => b.size - a.size);
+  const available = sorted.slice(3).reduce((s, d) => s + d.size, 0);
   return {
     available,
     protection: t - available,
@@ -165,12 +212,12 @@ export const CONFIG_CALC_MAP: Record<string, (drives: Drive[]) => RaidStats> = {
   'Mirror':   calcMirror,
   'RAID 5':   calcSingleParity,
   'RAID-Z1':  calcSingleParity,
-  'SHR':      calcSingleParity,
+  'SHR':      calcSHR,
   'Parity 1': calcUnraidParity1,
   'RAID 6':   calcDoubleParity,
   'RAID-Z2':  calcDoubleParity,
-  'SHR-2':    calcDoubleParity,
-  'Parity 2': calcDoubleParity,
+  'SHR-2':    calcSHR2,
+  'Parity 2': calcUnraidParity2,
   'RAID-Z3':  calcTripleParity,
   'Parity 3': calcUnraidParity3,
   'RAID 10':  calcRaid10,


### PR DESCRIPTION
## Summary

- **SHR/SHR-2 split from RAID 5/6**: Synology's hybrid RAID uses `total - N*maxDrive` (parity = N largest drives' full capacity), while standard RAID 5/6/Z1/Z2/Z3 uses `(N-k) * minDrive` (all drives contribute only the smallest drive's worth per stripe). These were sharing the same functions, giving wrong results for mixed-size arrays.
- **RAID 5/6/Z1/Z2/Z3 mixed-drive fix**: e.g. `[8,8,8,8,4,4]` RAID 5 was 32 TB (wrong), now correctly 20 TB — validated against Synology's official RAID calculator.
- **Unraid Parity 2/3**: switched to sorted-slice approach so the N largest drives are parity (same logic as SnapRAID), fixing wrong results for mixed-size arrays.
- **Minimum drive thresholds**: RAID 6/Z2 now requires ≥4 drives, RAID-Z3 requires ≥5.
- **Tests**: 28 → 43 tests; new coverage for mixed-drive arrays and min-threshold edge cases.

## Test plan

- [x] `npm test` — 43/43 pass
- [x] Equal-size drive results unchanged (formulas are algebraically identical for uniform drives)
- [x] Mixed-drive results validated against Synology's official RAID calculator (`[8,8,8,8,4,4]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)