### PR TITLE
feat: add 32TB, 40TB, 48TB drive sizes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -124,7 +124,7 @@ const RAIDCalculator = () => {
   const vdevInfoRef = useRef<HTMLDivElement>(null);
   const snapraidInfoRef = useRef<HTMLDivElement>(null);
 
-  const driveSizes = [30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 3, 2, 1];
+  const driveSizes = [48, 40, 32, 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 3, 2, 1];
 
   const raidOptions = useMemo(() => ({
     'ZFS': ['RAID-Z1', 'RAID-Z2', 'RAID-Z3', 'Mirror', 'Striped'],


### PR DESCRIPTION
## Summary
- Adds 32TB, 40TB, 48TB to the drive size picker (Seagate Exos X HAMR enterprise drives)
- Inserted above existing 30TB; all other sizes unchanged

## Test plan
- [x] All 43 existing tests pass
- [x] Verify 48/40/32TB options appear in drive size dropdown
- [x] Confirm drives of those sizes can be added and capacity calculates correctly

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)