### PR TITLE
feat: add NVMe drive support with distinct visual treatment

### DIFF
--- a/src/app/ServerRack.tsx
+++ b/src/app/ServerRack.tsx
@@ -49,13 +49,8 @@ const ServerRack: React.FC<ServerRackProps> = ({
         marginBottom: '10px',
         border: '1px solid var(--rule)',
       }}>
-        <div style={{ display: 'flex', gap: '6px' }}>
-          <div style={{ width: 18, height: 28, background: 'var(--rule)', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div style={{ width: 10, height: 10, background: '#1a73e8', borderRadius: '1px' }} />
-          </div>
-          <div style={{ width: 18, height: 28, background: 'var(--rule)', borderRadius: '2px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <div style={{ width: 10, height: 10, background: '#1a73e8', borderRadius: '1px' }} />
-          </div>
+        <div style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-3)', letterSpacing: '0.06em' }}>
+          SRV-R2502 · 4U
         </div>
 
         <div style={{ display: 'flex', gap: '14px' }}>
@@ -76,9 +71,6 @@ const ServerRack: React.FC<ServerRackProps> = ({
           ))}
         </div>
 
-        <div style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-3)', letterSpacing: '0.06em' }}>
-          SRV-R2502 · 4U
-        </div>
       </div>
 
       {/* Drive bays */}
@@ -211,6 +203,11 @@ const ServerRack: React.FC<ServerRackProps> = ({
       }}>
         <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: 'var(--ink-3)' }}>
           {drives.length}/{maxSlots} bays occupied
+          {drives.some(d => !d.type || d.type === 'hdd') && (
+            <span style={{ color: 'var(--ok)', marginLeft: '8px' }}>
+              {drives.filter(d => !d.type || d.type === 'hdd').length} HDD
+            </span>
+          )}
           {hasNvme && (
             <span style={{ color: 'var(--nvme)', marginLeft: '8px' }}>
               {drives.filter(d => d.type === 'nvme').length} NVMe

--- a/src/app/ServerRack.tsx
+++ b/src/app/ServerRack.tsx
@@ -5,12 +5,18 @@ import React from 'react';
 interface Drive {
   id: number;
   size: number;
+  type?: 'hdd' | 'nvme';
 }
 
 interface ServerRackProps {
   drives: Drive[];
   onDriveClick: (id: number | null) => void;
   maxSlots?: number;
+}
+
+function formatSize(size: number): { value: string; unit: string } {
+  if (size < 1) return { value: String(Math.round(size * 1000)), unit: 'GB' };
+  return { value: String(size), unit: 'TB' };
 }
 
 const ServerRack: React.FC<ServerRackProps> = ({
@@ -21,6 +27,7 @@ const ServerRack: React.FC<ServerRackProps> = ({
   const drivesPerRow = 6;
   const rows = Math.ceil(maxSlots / drivesPerRow);
   const slots = Array.from({ length: maxSlots }, (_, i) => i);
+  const hasNvme = drives.some(d => d.type === 'nvme');
 
   return (
     <div style={{
@@ -52,10 +59,19 @@ const ServerRack: React.FC<ServerRackProps> = ({
         </div>
 
         <div style={{ display: 'flex', gap: '14px' }}>
-          {[['PWR', 'var(--ok)'], ['NET', 'var(--ok)'], ['HDD', drives.length > 0 ? 'var(--ok)' : 'var(--ink-3)']].map(([label, color]) => (
-            <div key={label} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '3px' }}>
-              <div style={{ width: 6, height: 6, borderRadius: '50%', background: color as string, boxShadow: drives.length > 0 ? `0 0 6px ${color}` : 'none' }} />
-              <span style={{ fontFamily: 'var(--mono)', fontSize: '9px', color: 'var(--ink-3)', letterSpacing: '0.05em' }}>{label}</span>
+          {[
+            ['PWR', 'var(--ok)', true],
+            ['NET', 'var(--ok)', true],
+            ['HDD', drives.some(d => !d.type || d.type === 'hdd') ? 'var(--ok)' : 'var(--ink-3)', drives.some(d => !d.type || d.type === 'hdd')],
+            ['NVMe', hasNvme ? 'var(--nvme)' : 'var(--ink-3)', hasNvme],
+          ].map(([label, color, active]) => (
+            <div key={label as string} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '3px' }}>
+              <div style={{
+                width: 6, height: 6, borderRadius: '50%',
+                background: color as string,
+                boxShadow: active ? `0 0 6px ${color}` : 'none',
+              }} />
+              <span style={{ fontFamily: 'var(--mono)', fontSize: '9px', color: 'var(--ink-3)', letterSpacing: '0.05em' }}>{label as string}</span>
             </div>
           ))}
         </div>
@@ -71,6 +87,13 @@ const ServerRack: React.FC<ServerRackProps> = ({
           <div key={rowIndex} style={{ display: 'grid', gridTemplateColumns: `repeat(${drivesPerRow}, 1fr)`, gap: '6px' }}>
             {slots.slice(rowIndex * drivesPerRow, (rowIndex + 1) * drivesPerRow).map((slotIndex) => {
               const drive = drives.find((_, i) => i === slotIndex);
+              const isNvme = drive?.type === 'nvme';
+              const { value, unit } = drive ? formatSize(drive.size) : { value: '', unit: '' };
+
+              const activeBorder = isNvme ? '1px solid rgba(0,212,255,0.45)' : '1px solid var(--rule)';
+              const activeBg = isNvme ? 'rgba(0,10,18,0.95)' : 'var(--paper-2)';
+              const ledColor = isNvme ? 'var(--nvme)' : 'var(--ok)';
+
               return (
                 <div
                   key={slotIndex}
@@ -80,35 +103,53 @@ const ServerRack: React.FC<ServerRackProps> = ({
                     aspectRatio: '3/1',
                     borderRadius: '3px',
                     overflow: 'hidden',
-                    border: drive
-                      ? '1px solid var(--rule)'
-                      : '1px dashed rgba(54,45,89,0.6)',
-                    background: drive ? 'var(--paper-2)' : 'var(--paper-3)',
+                    border: drive ? activeBorder : '1px dashed rgba(54,45,89,0.6)',
+                    background: drive ? activeBg : 'var(--paper-3)',
                     cursor: drive ? 'pointer' : 'default',
                     transition: 'border-color 0.2s, box-shadow 0.2s',
                   }}
                   onMouseEnter={e => {
                     if (drive) {
-                      (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--crit)';
-                      (e.currentTarget as HTMLDivElement).style.boxShadow = '0 0 8px rgba(250,127,170,0.25)';
+                      const el = e.currentTarget as HTMLDivElement;
+                      el.style.borderColor = isNvme ? 'var(--nvme)' : 'var(--crit)';
+                      el.style.boxShadow = isNvme
+                        ? '0 0 8px rgba(0,212,255,0.3)'
+                        : '0 0 8px rgba(250,127,170,0.25)';
                     }
                   }}
                   onMouseLeave={e => {
                     if (drive) {
-                      (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--rule)';
-                      (e.currentTarget as HTMLDivElement).style.boxShadow = 'none';
+                      const el = e.currentTarget as HTMLDivElement;
+                      el.style.borderColor = isNvme ? 'rgba(0,212,255,0.45)' : 'var(--rule)';
+                      el.style.boxShadow = 'none';
                     }
                   }}
                 >
                   {drive && (
-                    <div style={{ position: 'absolute', inset: 0, opacity: 0.12 }}>
-                      <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-                        <pattern id={`hc-${drive.id}`} patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="scale(0.5)">
-                          <rect width="100%" height="100%" fill="none" />
-                          <path d="M0,5 L2.5,0 L7.5,0 L10,5 L7.5,10 L2.5,10 Z" fill="var(--ok)" />
-                        </pattern>
-                        <rect width="100%" height="100%" fill={`url(#hc-${drive.id})`} />
-                      </svg>
+                    <div style={{ position: 'absolute', inset: 0, opacity: isNvme ? 0.18 : 0.12 }}>
+                      {isNvme ? (
+                        /* NVMe: circuit trace grid pattern */
+                        <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                          <defs>
+                            <pattern id={`nv-${drive.id}`} patternUnits="userSpaceOnUse" width="8" height="6">
+                              <rect x="0.5" y="1" width="7" height="4" fill="none" stroke="var(--nvme)" strokeWidth="0.6" rx="0.5" />
+                              <rect x="2" y="2.5" width="4" height="1" fill="var(--nvme)" rx="0.3" />
+                            </pattern>
+                          </defs>
+                          <rect width="100%" height="100%" fill={`url(#nv-${drive.id})`} />
+                        </svg>
+                      ) : (
+                        /* HDD: honeycomb pattern */
+                        <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                          <defs>
+                            <pattern id={`hc-${drive.id}`} patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="scale(0.5)">
+                              <rect width="100%" height="100%" fill="none" />
+                              <path d="M0,5 L2.5,0 L7.5,0 L10,5 L7.5,10 L2.5,10 Z" fill="var(--ok)" />
+                            </pattern>
+                          </defs>
+                          <rect width="100%" height="100%" fill={`url(#hc-${drive.id})`} />
+                        </svg>
+                      )}
                     </div>
                   )}
 
@@ -122,18 +163,27 @@ const ServerRack: React.FC<ServerRackProps> = ({
                           fontFamily: 'var(--mono)',
                           fontSize: '11px',
                           fontWeight: 500,
-                          color: 'var(--ink-2)',
-                          background: 'rgba(21,15,35,0.75)',
+                          color: isNvme ? 'var(--nvme)' : 'var(--ink-2)',
+                          background: isNvme ? 'rgba(0,8,14,0.82)' : 'rgba(21,15,35,0.75)',
                           padding: '2px 6px',
                           borderRadius: '2px',
                           letterSpacing: '0.03em',
                         }}>
-                          {drive.size}<span style={{ fontSize: '9px', color: 'var(--ink-3)', marginLeft: '1px' }}>TB</span>
+                          {value}<span style={{ fontSize: '9px', color: isNvme ? 'rgba(0,212,255,0.6)' : 'var(--ink-3)', marginLeft: '1px' }}>{unit}</span>
                         </span>
                       </div>
                       <div style={{ position: 'absolute', top: 3, right: 4 }}>
-                        <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--ok)', boxShadow: '0 0 4px var(--ok)' }} />
+                        <div style={{ width: 5, height: 5, borderRadius: '50%', background: ledColor, boxShadow: `0 0 4px ${ledColor}` }} />
                       </div>
+                      {isNvme && (
+                        <div style={{
+                          position: 'absolute', bottom: 2, left: 4,
+                          fontFamily: 'var(--mono)', fontSize: '7px',
+                          color: 'rgba(0,212,255,0.45)', letterSpacing: '0.06em',
+                        }}>
+                          M.2
+                        </div>
+                      )}
                     </>
                   ) : (
                     <div style={{
@@ -161,6 +211,11 @@ const ServerRack: React.FC<ServerRackProps> = ({
       }}>
         <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: 'var(--ink-3)' }}>
           {drives.length}/{maxSlots} bays occupied
+          {hasNvme && (
+            <span style={{ color: 'var(--nvme)', marginLeft: '8px' }}>
+              {drives.filter(d => d.type === 'nvme').length} NVMe
+            </span>
+          )}
         </span>
         <div style={{ display: 'flex', gap: '6px' }}>
           <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--warn)' }} />

--- a/src/app/VdevRack.tsx
+++ b/src/app/VdevRack.tsx
@@ -5,12 +5,18 @@ import React from 'react';
 interface Drive {
   id: number;
   size: number;
+  type?: 'hdd' | 'nvme';
 }
 
 interface VdevRackProps {
   drives: Drive[];
   type: string;
   vdevIndex: number;
+}
+
+function formatSize(size: number): { value: string; unit: string } {
+  if (size < 1) return { value: String(Math.round(size * 1000)), unit: 'GB' };
+  return { value: String(size), unit: 'TB' };
 }
 
 const VdevRack: React.FC<VdevRackProps> = ({ drives, type, vdevIndex }) => {
@@ -46,47 +52,68 @@ const VdevRack: React.FC<VdevRackProps> = ({ drives, type, vdevIndex }) => {
       <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
         {Array.from({ length: rows }).map((_, rowIndex) => (
           <div key={rowIndex} style={{ display: 'grid', gridTemplateColumns: `repeat(${drivesPerRow}, 1fr)`, gap: '4px' }}>
-            {drives.slice(rowIndex * drivesPerRow, (rowIndex + 1) * drivesPerRow).map((drive) => (
-              <div
-                key={drive.id}
-                style={{
-                  position: 'relative',
-                  aspectRatio: '3/1',
-                  borderRadius: '2px',
-                  overflow: 'hidden',
-                  border: '1px solid var(--rule)',
-                  background: 'var(--paper-2)',
-                }}
-              >
-                <div style={{ position: 'absolute', inset: 0, opacity: 0.1 }}>
-                  <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-                    <pattern id={`hcv-${drive.id}`} patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="scale(0.5)">
-                      <rect width="100%" height="100%" fill="none" />
-                      <path d="M0,5 L2.5,0 L7.5,0 L10,5 L7.5,10 L2.5,10 Z" fill="var(--accent)" />
-                    </pattern>
-                    <rect width="100%" height="100%" fill={`url(#hcv-${drive.id})`} />
-                  </svg>
-                </div>
-                <div style={{
-                  position: 'absolute', inset: 0,
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                }}>
-                  <span style={{
-                    fontFamily: 'var(--mono)',
-                    fontSize: '10px',
-                    color: 'var(--ink-2)',
-                    background: 'rgba(21,15,35,0.75)',
-                    padding: '1px 4px',
+            {drives.slice(rowIndex * drivesPerRow, (rowIndex + 1) * drivesPerRow).map((drive) => {
+              const isNvme = drive.type === 'nvme';
+              const { value, unit } = formatSize(drive.size);
+              return (
+                <div
+                  key={drive.id}
+                  style={{
+                    position: 'relative',
+                    aspectRatio: '3/1',
                     borderRadius: '2px',
+                    overflow: 'hidden',
+                    border: isNvme ? '1px solid rgba(0,212,255,0.35)' : '1px solid var(--rule)',
+                    background: isNvme ? 'rgba(0,10,18,0.95)' : 'var(--paper-2)',
+                  }}
+                >
+                  <div style={{ position: 'absolute', inset: 0, opacity: isNvme ? 0.18 : 0.1 }}>
+                    {isNvme ? (
+                      <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                        <defs>
+                          <pattern id={`nvv-${drive.id}`} patternUnits="userSpaceOnUse" width="8" height="6">
+                            <rect x="0.5" y="1" width="7" height="4" fill="none" stroke="var(--nvme)" strokeWidth="0.6" rx="0.5" />
+                            <rect x="2" y="2.5" width="4" height="1" fill="var(--nvme)" rx="0.3" />
+                          </pattern>
+                        </defs>
+                        <rect width="100%" height="100%" fill={`url(#nvv-${drive.id})`} />
+                      </svg>
+                    ) : (
+                      <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+                        <defs>
+                          <pattern id={`hcv-${drive.id}`} patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="scale(0.5)">
+                            <rect width="100%" height="100%" fill="none" />
+                            <path d="M0,5 L2.5,0 L7.5,0 L10,5 L7.5,10 L2.5,10 Z" fill="var(--accent)" />
+                          </pattern>
+                        </defs>
+                        <rect width="100%" height="100%" fill={`url(#hcv-${drive.id})`} />
+                      </svg>
+                    )}
+                  </div>
+                  <div style={{
+                    position: 'absolute', inset: 0,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
                   }}>
-                    {drive.size}<span style={{ fontSize: '8px', color: 'var(--ink-3)' }}>TB</span>
-                  </span>
+                    <span style={{
+                      fontFamily: 'var(--mono)',
+                      fontSize: '10px',
+                      color: isNvme ? 'var(--nvme)' : 'var(--ink-2)',
+                      background: isNvme ? 'rgba(0,8,14,0.82)' : 'rgba(21,15,35,0.75)',
+                      padding: '1px 4px',
+                      borderRadius: '2px',
+                    }}>
+                      {value}<span style={{ fontSize: '8px', color: isNvme ? 'rgba(0,212,255,0.55)' : 'var(--ink-3)' }}>{unit}</span>
+                    </span>
+                  </div>
+                  <div style={{ position: 'absolute', top: 2, right: 3 }}>
+                    <div style={{
+                      width: 4, height: 4, borderRadius: '50%',
+                      background: isNvme ? 'var(--nvme)' : 'var(--ok)',
+                    }} />
+                  </div>
                 </div>
-                <div style={{ position: 'absolute', top: 2, right: 3 }}>
-                  <div style={{ width: 4, height: 4, borderRadius: '50%', background: 'var(--ok)' }} />
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         ))}
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,7 @@
   --display:   var(--font-display, "Barlow Condensed"), ui-sans-serif, sans-serif;
   --sans:      var(--font-sans, "Rubik"), ui-sans-serif, sans-serif;
   --mono:      var(--font-mono, "JetBrains Mono"), ui-monospace, monospace;
+  --nvme:      #00d4ff;
 }
 
 /* ── Base ──────────────────────────────────────── */
@@ -115,6 +116,44 @@ body {
   border-color: var(--accent);
   color: var(--accent);
   background: rgba(106, 95, 193, 0.12);
+}
+.drive-btn--nvme {
+  border-color: rgba(0, 212, 255, 0.28);
+  color: var(--nvme);
+}
+.drive-btn--nvme:hover {
+  background: rgba(0, 212, 255, 0.1);
+  border-color: var(--nvme);
+  color: #fff;
+}
+
+/* ── Media type toggle ─────────────────────────── */
+.media-tab {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ink-3);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 12px;
+  cursor: pointer;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.15s, color 0.15s;
+}
+.media-tab--hdd-active {
+  background: var(--paper);
+  color: var(--ok);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.35);
+}
+.media-tab--nvme-active {
+  background: var(--paper);
+  color: var(--nvme);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.35);
+}
+.media-tab:hover:not(.media-tab--hdd-active):not(.media-tab--nvme-active) {
+  color: var(--ink-2);
 }
 
 /* ── Select ────────────────────────────────────── */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -126,7 +126,8 @@ const RAIDCalculator = () => {
   const snapraidInfoRef = useRef<HTMLDivElement>(null);
 
   const driveSizes = [48, 40, 32, 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 3, 2, 1];
-  const nvmeSizes = [16, 8, 4, 2, 1, 0.512, 0.256]; // stored in TB
+  const nvmeSizesStandard    = [16, 8, 4, 2, 1, 0.512, 0.256];           // power-of-2 NAND, full user capacity
+  const nvmeSizesEnterprise  = [15.36, 7.68, 3.84, 1.92, 0.96, 0.48, 0.24, 0.12]; // ~6% over-provisioned
 
   const raidOptions = useMemo(() => ({
     'ZFS': ['RAID-Z1', 'RAID-Z2', 'RAID-Z3', 'Mirror', 'Striped'],
@@ -627,27 +628,65 @@ const RAIDCalculator = () => {
         </div>
 
         {/* Drive size buttons */}
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '20px' }}>
-          {driveMediaType === 'hdd' ? (
-            driveSizes.map(size => (
+        {driveMediaType === 'hdd' ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '20px' }}>
+            {driveSizes.map(size => (
               <button key={size} className="drive-btn" onClick={() => addDrive(size, 'hdd')}>
                 {size} TB
               </button>
-            ))
-          ) : (
-            nvmeSizes.map(size => (
-              <button key={size} className="drive-btn drive-btn--nvme" onClick={() => addDrive(size, 'nvme')}>
-                {formatDriveSize(size)}
+            ))}
+            <button
+              className={`drive-btn ${showComparisonMode ? 'drive-btn--active' : ''}`}
+              onClick={() => setShowComparisonMode(!showComparisonMode)}
+            >
+              {showComparisonMode ? '← Single' : 'Compare →'}
+            </button>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '20px' }}>
+            {/* Standard (full user-visible capacity) */}
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', alignItems: 'center' }}>
+              <span style={{ fontFamily: 'var(--mono)', fontSize: '9px', color: 'var(--nvme)', textTransform: 'uppercase', letterSpacing: '0.1em', minWidth: '60px' }}>
+                Standard
+              </span>
+              {nvmeSizesStandard.map(size => (
+                <button key={size} className="drive-btn drive-btn--nvme" onClick={() => addDrive(size, 'nvme')}>
+                  {formatDriveSize(size)}
+                </button>
+              ))}
+            </div>
+            {/* Enterprise / prosumer: ~6% over-provisioned, odd sizes */}
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', alignItems: 'center' }}>
+              <span
+                style={{ fontFamily: 'var(--mono)', fontSize: '9px', color: 'var(--ink-3)', textTransform: 'uppercase', letterSpacing: '0.1em', minWidth: '60px', cursor: 'help' }}
+                title="Over-provisioned: manufacturer reserves ~6% of NAND for wear leveling and garbage collection"
+              >
+                Ent. OP
+              </span>
+              {nvmeSizesEnterprise.map(size => {
+                const rawNand: Record<number, string> = {
+                  0.12: '128 GB', 0.24: '256 GB', 0.48: '512 GB', 0.96: '1 TB',
+                  1.92: '2 TB', 3.84: '4 TB', 7.68: '8 TB', 15.36: '16 TB',
+                };
+                return (
+                  <button key={size} className="drive-btn drive-btn--nvme" onClick={() => addDrive(size, 'nvme')}
+                    title={`${formatDriveSize(size)} user-visible · ${rawNand[size]} raw NAND (~6% over-provisioned)`}
+                  >
+                    {formatDriveSize(size)}
+                  </button>
+                );
+              })}
+            </div>
+            <div style={{ display: 'flex', gap: '6px' }}>
+              <button
+                className={`drive-btn ${showComparisonMode ? 'drive-btn--active' : ''}`}
+                onClick={() => setShowComparisonMode(!showComparisonMode)}
+              >
+                {showComparisonMode ? '← Single' : 'Compare →'}
               </button>
-            ))
-          )}
-          <button
-            className={`drive-btn ${showComparisonMode ? 'drive-btn--active' : ''}`}
-            onClick={() => setShowComparisonMode(!showComparisonMode)}
-          >
-            {showComparisonMode ? '← Single' : 'Compare →'}
-          </button>
-        </div>
+            </div>
+          </div>
+        )}
 
         {/* Comparison mode tabs */}
         {showComparisonMode && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import ServerRack from './ServerRack';
 import VdevRack from './VdevRack';
-import { type Drive, calcVdevRaid, calcConfigRaid, calcSnapRaid } from './raidCalc';
+import { type Drive, calcVdevRaid, calcConfigRaid, calcSnapRaid, formatDriveSize } from './raidCalc';
 
 interface Vdev {
   id: number;
@@ -43,14 +43,14 @@ const VdevManagerDriveGrid = ({ drives }: { drives: Drive[] }) => (
                 aspectRatio: '3/1',
                 borderRadius: '2px',
                 overflow: 'hidden',
-                border: '1px solid var(--rule)',
-                background: 'var(--paper-2)',
+                border: drive.type === 'nvme' ? '1px solid rgba(0,212,255,0.35)' : '1px solid var(--rule)',
+                background: drive.type === 'nvme' ? 'rgba(0,10,18,0.95)' : 'var(--paper-2)',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
               }}>
-                <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: 'var(--ink-2)' }}>
-                  {drive.size}TB
+                <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: drive.type === 'nvme' ? 'var(--nvme)' : 'var(--ink-2)' }}>
+                  {formatDriveSize(drive.size)}
                 </span>
               </div>
             ))}
@@ -104,6 +104,7 @@ const RAID_DESCRIPTIONS: Record<string, { canFail: string; efficiency: string; m
 
 const RAIDCalculator = () => {
   const [driveSize, setDriveSize] = useState(20);
+  const [driveMediaType, setDriveMediaType] = useState<'hdd' | 'nvme'>('hdd');
   const [showComparisonMode, setShowComparisonMode] = useState(false);
   const [activeConfigIndex, setActiveConfigIndex] = useState(0);
 
@@ -125,6 +126,7 @@ const RAIDCalculator = () => {
   const snapraidInfoRef = useRef<HTMLDivElement>(null);
 
   const driveSizes = [48, 40, 32, 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 3, 2, 1];
+  const nvmeSizes = [16, 8, 4, 2, 1, 0.512, 0.256]; // stored in TB
 
   const raidOptions = useMemo(() => ({
     'ZFS': ['RAID-Z1', 'RAID-Z2', 'RAID-Z3', 'Mirror', 'Striped'],
@@ -190,11 +192,11 @@ const RAIDCalculator = () => {
 
   const [driveCapHit, setDriveCapHit] = useState(false);
 
-  const addDrive = (size: number) => {
+  const addDrive = (size: number, type: 'hdd' | 'nvme' = 'hdd') => {
     const activeConfig = configs[activeConfigIndex];
     const totalDrives = activeConfig.selectedDrives.length + activeConfig.vdevs.reduce((s, v) => s + v.drives.length, 0);
     if (totalDrives < 24) {
-      updateConfig(activeConfigIndex, { selectedDrives: [...activeConfig.selectedDrives, { id: Date.now(), size }] });
+      updateConfig(activeConfigIndex, { selectedDrives: [...activeConfig.selectedDrives, { id: Date.now(), size, type }] });
       setDriveCapHit(false);
     } else {
       setDriveCapHit(true);
@@ -239,7 +241,7 @@ const RAIDCalculator = () => {
     if (allDrives.length === 0) return;
     const dstTotal = dst.selectedDrives.length + dst.vdevs.reduce((s, v) => s + v.drives.length, 0);
     const slots = Math.max(0, 24 - dstTotal);
-    const newDrives = allDrives.slice(0, slots).map(drive => ({ id: Date.now() + Math.random(), size: drive.size }));
+    const newDrives = allDrives.slice(0, slots).map(drive => ({ id: Date.now() + Math.random(), size: drive.size, type: drive.type }));
     if (newDrives.length === 0) return;
     updateConfig(toIndex, { selectedDrives: [...dst.selectedDrives, ...newDrives] });
   };
@@ -335,9 +337,15 @@ const RAIDCalculator = () => {
   // Reliability -> color
   const reliabilityColor = (r: number) => r > 80 ? 'var(--ok)' : r > 50 ? 'var(--warn)' : 'var(--crit)';
 
+  const speedBarMax = (config: StorageConfig) => {
+    const allDrives = [...config.selectedDrives, ...config.vdevs.flatMap(v => v.drives)];
+    return allDrives.length > 0 && allDrives.every(d => d.type === 'nvme') ? 25000 : 1500;
+  };
+
   const renderStorageConfig = (config: StorageConfig, index: number, stats: ReturnType<typeof calculateStorage>) => {
     const accentColor = index === 0 ? 'var(--ok)' : 'var(--accent)';
     const efficiency = stats.total > 0 ? ((stats.available / stats.total) * 100) : 0;
+    const spdMax = speedBarMax(config);
 
     return (
       <div>
@@ -536,7 +544,7 @@ const RAIDCalculator = () => {
                     <div style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-3)' }}>MB/s</div>
                   </div>
                   <div className="bar-track">
-                    <div className="bar-fill bar-fill--accent" style={{ width: `${Math.min(100, (stats.readSpeed / 1000) * 100)}%` }} />
+                    <div className="bar-fill bar-fill--accent" style={{ width: `${Math.min(100, (stats.readSpeed / spdMax) * 100)}%` }} />
                   </div>
                 </div>
                 {/* Write speed */}
@@ -547,7 +555,7 @@ const RAIDCalculator = () => {
                     <div style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-3)' }}>MB/s</div>
                   </div>
                   <div className="bar-track">
-                    <div className="bar-fill bar-fill--ok" style={{ width: `${Math.min(100, (stats.writeSpeed / 1000) * 100)}%` }} />
+                    <div className="bar-fill bar-fill--ok" style={{ width: `${Math.min(100, (stats.writeSpeed / spdMax) * 100)}%` }} />
                   </div>
                 </div>
                 {/* Reliability */}
@@ -590,20 +598,49 @@ const RAIDCalculator = () => {
       <section style={{ marginBottom: '48px' }} className="rise rise-1">
         <div className="section-label">
           <span>Add Drives</span>
-          {(configs[activeConfigIndex].selectedDrives.length > 0 || configs[activeConfigIndex].vdevs.length > 0) && (
-            <span style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-3)' }}>
-              click a bay to remove
-            </span>
-          )}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            {(configs[activeConfigIndex].selectedDrives.length > 0 || configs[activeConfigIndex].vdevs.length > 0) && (
+              <span style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-3)' }}>
+                click a bay to remove
+              </span>
+            )}
+            {/* HDD / NVMe toggle */}
+            <div style={{
+              display: 'flex', gap: '2px',
+              background: 'var(--paper-3)', padding: '2px', borderRadius: '5px',
+              border: '1px solid var(--rule)',
+            }}>
+              <button
+                className={`media-tab ${driveMediaType === 'hdd' ? 'media-tab--hdd-active' : ''}`}
+                onClick={() => setDriveMediaType('hdd')}
+              >
+                HDD
+              </button>
+              <button
+                className={`media-tab ${driveMediaType === 'nvme' ? 'media-tab--nvme-active' : ''}`}
+                onClick={() => setDriveMediaType('nvme')}
+              >
+                NVMe
+              </button>
+            </div>
+          </div>
         </div>
 
         {/* Drive size buttons */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '20px' }}>
-          {driveSizes.map(size => (
-            <button key={size} className="drive-btn" onClick={() => addDrive(size)}>
-              {size} TB
-            </button>
-          ))}
+          {driveMediaType === 'hdd' ? (
+            driveSizes.map(size => (
+              <button key={size} className="drive-btn" onClick={() => addDrive(size, 'hdd')}>
+                {size} TB
+              </button>
+            ))
+          ) : (
+            nvmeSizes.map(size => (
+              <button key={size} className="drive-btn drive-btn--nvme" onClick={() => addDrive(size, 'nvme')}>
+                {formatDriveSize(size)}
+              </button>
+            ))
+          )}
           <button
             className={`drive-btn ${showComparisonMode ? 'drive-btn--active' : ''}`}
             onClick={() => setShowComparisonMode(!showComparisonMode)}

--- a/src/app/raidCalc.ts
+++ b/src/app/raidCalc.ts
@@ -1,6 +1,7 @@
 export interface Drive {
   id: number;
   size: number;
+  type?: 'hdd' | 'nvme';
 }
 
 export interface RaidStats {
@@ -11,8 +12,23 @@ export interface RaidStats {
   reliability: number;
 }
 
-const BASE_READ = 150;
-const BASE_WRITE = 140;
+const BASE_READ_HDD = 150;
+const BASE_WRITE_HDD = 140;
+const BASE_READ_NVME = 3200;
+const BASE_WRITE_NVME = 2800;
+
+export function formatDriveSize(sizeInTB: number): string {
+  if (sizeInTB < 1) return `${Math.round(sizeInTB * 1000)} GB`;
+  return `${sizeInTB} TB`;
+}
+
+function getBaseSpeeds(drives: Drive[]): { r: number; w: number } {
+  if (drives.length === 0) return { r: BASE_READ_HDD, w: BASE_WRITE_HDD };
+  const nvmeCount = drives.filter(d => d.type === 'nvme').length;
+  if (nvmeCount === drives.length) return { r: BASE_READ_NVME, w: BASE_WRITE_NVME };
+  if (nvmeCount > 0) return { r: BASE_READ_HDD * 2, w: BASE_WRITE_HDD * 2 };
+  return { r: BASE_READ_HDD, w: BASE_WRITE_HDD };
+}
 
 function sumDrives(drives: Drive[]): number {
   return drives.reduce((s, d) => s + d.size, 0);
@@ -27,120 +43,130 @@ function minDrive(drives: Drive[]): number {
 }
 
 export function calcStriped(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   return {
     available: t,
     protection: 0,
-    readSpeed: BASE_READ * drives.length * 0.9,
-    writeSpeed: BASE_WRITE * drives.length * 0.9,
+    readSpeed: r * drives.length * 0.9,
+    writeSpeed: w * drives.length * 0.9,
     reliability: 0,
   };
 }
 
 export function calcMirror(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   const available = drives.length > 0 ? Math.min(...drives.map(d => d.size)) : 0;
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * Math.min(drives.length, 2) * 0.9,
-    writeSpeed: BASE_WRITE * 0.95,
+    readSpeed: r * Math.min(drives.length, 2) * 0.9,
+    writeSpeed: w * 0.95,
     reliability: 90,
   };
 }
 
 // RAID 5 / RAID-Z1 — 1 distributed parity stripe; usable = (N-1) × smallest drive
 export function calcSingleParity(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   const available = drives.length > 1 ? (drives.length - 1) * minDrive(drives) : 0;
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * (drives.length - 1) * 0.8,
-    writeSpeed: BASE_WRITE * (drives.length - 1) * 0.7,
+    readSpeed: r * (drives.length - 1) * 0.8,
+    writeSpeed: w * (drives.length - 1) * 0.7,
     reliability: 70,
   };
 }
 
 // RAID 6 / RAID-Z2 — 2 distributed parity stripes; usable = (N-2) × smallest drive, minimum 4 drives
 export function calcDoubleParity(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   const available = drives.length > 3 ? (drives.length - 2) * minDrive(drives) : 0;
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * (drives.length - 2) * 0.8,
-    writeSpeed: BASE_WRITE * (drives.length - 2) * 0.6,
+    readSpeed: r * (drives.length - 2) * 0.8,
+    writeSpeed: w * (drives.length - 2) * 0.6,
     reliability: 85,
   };
 }
 
 // RAID-Z3 — 3 distributed parity stripes; usable = (N-3) × smallest drive, minimum 5 drives
 export function calcTripleParity(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   const available = drives.length > 4 ? (drives.length - 3) * minDrive(drives) : 0;
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * (drives.length - 3) * 0.8,
-    writeSpeed: BASE_WRITE * (drives.length - 3) * 0.5,
+    readSpeed: r * (drives.length - 3) * 0.8,
+    writeSpeed: w * (drives.length - 3) * 0.5,
     reliability: 95,
   };
 }
 
 // SHR (Synology Hybrid RAID) — largest drive is parity; smaller drives use remaining space fully
 export function calcSHR(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   const available = drives.length > 1 ? t - maxDrive(drives) : 0;
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * (drives.length - 1) * 0.8,
-    writeSpeed: BASE_WRITE * (drives.length - 1) * 0.7,
+    readSpeed: r * (drives.length - 1) * 0.8,
+    writeSpeed: w * (drives.length - 1) * 0.7,
     reliability: 70,
   };
 }
 
 // SHR-2 (Synology Hybrid RAID 2) — 2 largest drives are parity overhead; minimum 4 drives
 export function calcSHR2(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   const available = drives.length > 3 ? t - 2 * maxDrive(drives) : 0;
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * (drives.length - 2) * 0.8,
-    writeSpeed: BASE_WRITE * (drives.length - 2) * 0.6,
+    readSpeed: r * (drives.length - 2) * 0.8,
+    writeSpeed: w * (drives.length - 2) * 0.6,
     reliability: 85,
   };
 }
 
 export function calcRaid10(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   const available = t / 2;
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * (drives.length / 2) * 0.95,
-    writeSpeed: BASE_WRITE * (drives.length / 2) * 0.9,
+    readSpeed: r * (drives.length / 2) * 0.95,
+    writeSpeed: w * (drives.length / 2) * 0.9,
     reliability: 80,
   };
 }
 
 // Unraid Parity 1 — lower sequential perf than Z1
 export function calcUnraidParity1(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   const available = drives.length > 1 ? t - maxDrive(drives) : 0;
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * Math.min(1.5, drives.length * 0.2),
-    writeSpeed: BASE_WRITE * 0.6,
+    readSpeed: r * Math.min(1.5, drives.length * 0.2),
+    writeSpeed: w * 0.6,
     reliability: 70,
   };
 }
 
 // Unraid Parity 2 — 2 largest drives are parity; data drives keep full capacity
 export function calcUnraidParity2(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   if (drives.length <= 2) return { available: 0, protection: t, readSpeed: 0, writeSpeed: 0, reliability: 0 };
   const sorted = [...drives].sort((a, b) => b.size - a.size);
@@ -148,14 +174,15 @@ export function calcUnraidParity2(drives: Drive[]): RaidStats {
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * Math.min(1.5, drives.length * 0.2),
-    writeSpeed: BASE_WRITE * 0.5,
+    readSpeed: r * Math.min(1.5, drives.length * 0.2),
+    writeSpeed: w * 0.5,
     reliability: 85,
   };
 }
 
 // Unraid Parity 3 — 3 largest drives are parity; data drives keep full capacity
 export function calcUnraidParity3(drives: Drive[]): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   if (drives.length <= 3) return { available: 0, protection: t, readSpeed: 0, writeSpeed: 0, reliability: 0 };
   const sorted = [...drives].sort((a, b) => b.size - a.size);
@@ -163,14 +190,15 @@ export function calcUnraidParity3(drives: Drive[]): RaidStats {
   return {
     available,
     protection: t - available,
-    readSpeed: BASE_READ * Math.min(1.5, drives.length * 0.2),
-    writeSpeed: BASE_WRITE * 0.35,
+    readSpeed: r * Math.min(1.5, drives.length * 0.2),
+    writeSpeed: w * 0.35,
     reliability: 95,
   };
 }
 
 // SnapRAID — parity drives are the largest drives; data drives keep full capacity
 export function calcSnapRaid(drives: Drive[], parityCount: number): RaidStats {
+  const { r, w } = getBaseSpeeds(drives);
   const t = sumDrives(drives);
   if (drives.length <= parityCount) {
     return { available: 0, protection: t, readSpeed: 0, writeSpeed: 0, reliability: 0 };
@@ -181,8 +209,8 @@ export function calcSnapRaid(drives: Drive[], parityCount: number): RaidStats {
   return {
     available: dataSize,
     protection: paritySize,
-    readSpeed: BASE_READ * 0.95,
-    writeSpeed: BASE_WRITE * 0.9,
+    readSpeed: r * 0.95,
+    writeSpeed: w * 0.9,
     reliability: Math.min(95, 50 + parityCount * 15),
   };
 }
@@ -190,8 +218,8 @@ export function calcSnapRaid(drives: Drive[], parityCount: number): RaidStats {
 const DEFAULT_STATS: RaidStats = {
   available: 0,
   protection: 0,
-  readSpeed: BASE_READ,
-  writeSpeed: BASE_WRITE,
+  readSpeed: BASE_READ_HDD,
+  writeSpeed: BASE_WRITE_HDD,
   reliability: 50,
 };
 


### PR DESCRIPTION
## Summary

- Adds NVMe as a first-class drive type alongside HDD with completely distinct visuals
- HDD/NVMe segmented toggle in the Add Drives section; NVMe sizes: 256 GB, 512 GB, 1 TB, 2 TB, 4 TB, 8 TB, 16 TB
- NVMe bays: dark cyan background, circuit-trace SVG pattern, cyan text/LED, M.2 badge — vs HDD's honeycomb/green
- Server rack header gains a "NVMe" indicator (cyan); footer shows NVMe drive count
- Speed calculations: all-NVMe arrays use 3200/2800 MB/s base; mixed arrays use HDD×2; performance bar scales to 25 000 MB/s for NVMe configs
- `--nvme: #00d4ff` design token + new CSS classes for toggle and NVMe drive buttons
- `formatDriveSize()` utility exported from raidCalc — renders sub-TB as GB (512 GB, 256 GB), 1 TB+ as decimal TB
- `type` field preserved through drive copy, vdev creation, and all rack components

## Test plan

- [x] Add NVMe drives (256 GB, 512 GB, 1 TB, 4 TB) — verify cyan visuals in rack bays, M.2 badge, cyan LED
- [x] Add HDD drives alongside — verify green honeycomb bays unchanged, NVMe indicator lit in header
- [x] Toggle HDD/NVMe selector — verify correct size buttons appear for each type
- [x] Create ZFS vdev from NVMe drives — verify VdevRack shows cyan circuit pattern
- [x] Check performance stats on all-NVMe config vs mixed vs all-HDD (speeds should differ significantly)
- [x] Compare mode with one NVMe config and one HDD config
- [x] Copy drives between configs in compare mode — verify type is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)