### PR TITLE
feat: server chassis UI with hot-swap caddy design and enterprise NVMe distinction

### DIFF
--- a/.changeset/nvme-enterprise-caddy.md
+++ b/.changeset/nvme-enterprise-caddy.md
@@ -1,0 +1,5 @@
+---
+"storage-planner": minor
+---
+
+Add enterprise NVMe drive type with distinct amber caddy visual, move Compare toggle to section header, and fix SnapRAID NaN crash on filesystem switch.

--- a/src/app/ServerRack.tsx
+++ b/src/app/ServerRack.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 interface Drive {
   id: number;
   size: number;
-  type?: 'hdd' | 'nvme';
+  type?: 'hdd' | 'nvme' | 'nvme-ent';
 }
 
 interface ServerRackProps {
@@ -19,206 +19,357 @@ function formatSize(size: number): { value: string; unit: string } {
   return { value: String(size), unit: 'TB' };
 }
 
-const ServerRack: React.FC<ServerRackProps> = ({
-  drives,
-  onDriveClick,
-  maxSlots = 24
-}) => {
-  const drivesPerRow = 6;
-  const rows = Math.ceil(maxSlots / drivesPerRow);
-  const slots = Array.from({ length: maxSlots }, (_, i) => i);
-  const hasNvme = drives.some(d => d.type === 'nvme');
+// Diamond-dot mesh — the iconic perforated airflow grille on Dell PE hot-swap caddies.
+function meshStyle(tint: 'warm' | 'cool' | 'ember'): React.CSSProperties {
+  const hole = tint === 'cool' ? 'rgba(2,6,12,1)' : tint === 'ember' ? 'rgba(12,6,0,1)' : 'rgba(0,0,0,1)';
+  const ground = tint === 'cool' ? '#1a1c22' : tint === 'ember' ? '#1c1a16' : '#1a1a1d';
+  return {
+    backgroundColor: ground,
+    backgroundImage: `
+      radial-gradient(${hole} 0.9px, transparent 1.2px),
+      radial-gradient(${hole} 0.9px, transparent 1.2px)
+    `,
+    backgroundSize: '4px 4px, 4px 4px',
+    backgroundPosition: '0 0, 2px 2px',
+  };
+}
+
+function EmptyBay({ label }: { label: string }) {
+  return (
+    <div style={{
+      width: '100%', height: '100%', borderRadius: 2,
+      background: 'linear-gradient(180deg, #050506 0%, #020203 100%)',
+      boxShadow: 'inset 0 0 0 1px #14141a, inset 0 2px 4px rgba(0,0,0,0.85)',
+      position: 'relative',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+    }}>
+      <span style={{ color: '#26262e', fontSize: 14, fontWeight: 300 }}>+</span>
+      <div style={{
+        position: 'absolute', left: 4, top: '50%', transform: 'translateY(-50%)',
+        fontSize: 7, color: '#26262e', letterSpacing: 0.5,
+        fontFamily: 'var(--mono)',
+      }}>{label}</div>
+    </div>
+  );
+}
+
+interface CaddyProps {
+  kind: 'hdd' | 'nvme' | 'nvme-ent';
+  value: string;
+  unit: string;
+  slot: string;
+  onClick: () => void;
+}
+
+function Caddy({ kind, value, unit, slot, onClick }: CaddyProps) {
+  const isNvme = kind === 'nvme';
+  const isEnt = kind === 'nvme-ent';
+  const ledColor = isNvme ? 'var(--nvme)' : isEnt ? 'var(--nvme-ent)' : 'var(--ok)';
+  const stickerBg = isNvme
+    ? 'linear-gradient(180deg, #07131c 0%, #03080e 100%)'
+    : isEnt
+    ? 'linear-gradient(180deg, #1c0f00 0%, #0e0700 100%)'
+    : 'linear-gradient(180deg, #f3efe2 0%, #d8d3c2 100%)';
+  const stickerColor = isNvme ? 'var(--nvme)' : isEnt ? 'var(--nvme-ent)' : '#1a1a1d';
+  const stickerLabel = isNvme ? 'NVMe' : isEnt ? 'ENT' : 'SAS';
+  const stickerShadow = isNvme
+    ? 'inset 0 0 0 1px rgba(41,225,255,0.5), 0 0 5px rgba(41,225,255,0.18), 0 1px 1px rgba(0,0,0,0.6)'
+    : isEnt
+    ? 'inset 0 0 0 1px rgba(240,165,0,0.5), 0 0 5px rgba(240,165,0,0.18), 0 1px 1px rgba(0,0,0,0.6)'
+    : 'inset 0 1px 0 rgba(255,255,255,0.6), 0 1px 1px rgba(0,0,0,0.6), 0 0 0 1px rgba(0,0,0,0.4)';
+  const stickerTextShadow = isNvme ? '0 0 3px rgba(41,225,255,0.6)' : isEnt ? '0 0 3px rgba(240,165,0,0.6)' : 'none';
+
+  return (
+    <button
+      onClick={onClick}
+      title={`${value} ${unit} ${stickerLabel} — click to remove`}
+      style={{
+        all: 'unset', cursor: 'pointer', display: 'block',
+        width: '100%', height: '100%', position: 'relative',
+        borderRadius: 2,
+        background: 'linear-gradient(180deg, #2a2a2e 0%, #1a1a1d 50%, #0e0e10 100%)',
+        boxShadow: `
+          inset 0 1px 0 rgba(255,255,255,0.1),
+          inset 0 -1px 0 rgba(0,0,0,0.7),
+          inset 1px 0 0 rgba(255,255,255,0.05),
+          inset -1px 0 0 rgba(0,0,0,0.5),
+          0 1px 2px rgba(0,0,0,0.5)
+        `,
+        overflow: 'hidden', transition: 'transform 0.08s',
+      }}
+      onMouseDown={e => { (e.currentTarget as HTMLElement).style.transform = 'translateY(1px)'; }}
+      onMouseUp={e => { (e.currentTarget as HTMLElement).style.transform = 'translateY(0)'; }}
+      onMouseLeave={e => { (e.currentTarget as HTMLElement).style.transform = 'translateY(0)'; }}
+    >
+      {/* Handle strip with LEDs */}
+      <div style={{
+        position: 'absolute', left: 0, top: 0, bottom: 0, width: 14,
+        background: 'linear-gradient(180deg, #1d1d20 0%, #101012 100%)',
+        boxShadow: 'inset -1px 0 0 rgba(0,0,0,0.6), inset 1px 0 0 rgba(255,255,255,0.05)',
+      }}>
+        <div style={{
+          position: 'absolute', left: '50%', top: 5,
+          transform: 'translateX(-50%)',
+          display: 'flex', flexDirection: 'column', gap: 4,
+        }}>
+          <span style={{
+            width: 3.5, height: 3.5, borderRadius: '50%', display: 'block',
+            background: '#1de9b6',
+            boxShadow: '0 0 4px #1de9b6, inset 0 0 1px rgba(255,255,255,0.6)',
+          }} />
+          <span style={{
+            width: 3.5, height: 3.5, borderRadius: '50%', display: 'block',
+            background: ledColor,
+            boxShadow: `0 0 5px ${ledColor}, inset 0 0 1px rgba(255,255,255,0.6)`,
+            animation: isNvme ? 'caddy-blink-fast 0.9s ease-in-out infinite' : isEnt ? 'caddy-blink-fast 1.2s ease-in-out infinite' : 'caddy-blink 1.6s ease-in-out infinite',
+          }} />
+        </div>
+        <div style={{
+          position: 'absolute', left: '50%', top: 22, bottom: 4,
+          width: 1, background: 'rgba(0,0,0,0.6)',
+          boxShadow: '1px 0 0 rgba(255,255,255,0.06)',
+          transform: 'translateX(-50%)',
+        }} />
+      </div>
+
+      {/* Sticker label */}
+      <div style={{
+        position: 'absolute', left: 17, top: '50%', transform: 'translateY(-50%)',
+        background: stickerBg, color: stickerColor,
+        padding: '2px 4px', fontSize: 7.5, fontWeight: 700, letterSpacing: 0.2,
+        borderRadius: 1, display: 'flex', flexDirection: 'column',
+        alignItems: 'flex-start', gap: 0,
+        boxShadow: stickerShadow, textShadow: stickerTextShadow,
+        zIndex: 3, lineHeight: 1.1, minWidth: 32,
+        fontFamily: 'var(--mono)',
+      }}>
+        <span style={{ fontSize: 6, opacity: isNvme ? 0.85 : 0.7, letterSpacing: 0.5 }}>{stickerLabel}</span>
+        <span style={{ fontSize: 8, fontWeight: 700 }}>
+          {value}<span style={{ fontSize: 5.5, opacity: 0.7, marginLeft: 1 }}>{unit}</span>
+        </span>
+      </div>
+
+      {/* Diamond-mesh airflow grille */}
+      <div style={{
+        position: 'absolute', left: 53, right: 4, top: 4, bottom: 4,
+        ...meshStyle(isNvme ? 'cool' : isEnt ? 'ember' : 'warm'),
+        borderRadius: 1.5,
+        boxShadow: `
+          inset 0 1px 0 rgba(255,255,255,0.06),
+          inset 0 -1px 0 rgba(0,0,0,0.6),
+          inset 0 0 0 1px rgba(0,0,0,0.65)
+        `,
+        overflow: 'hidden',
+      }}>
+        <div style={{
+          position: 'absolute', inset: 0,
+          boxShadow: 'inset 0 2px 3px rgba(0,0,0,0.55)',
+          pointerEvents: 'none',
+        }} />
+      </div>
+
+      {/* Slot number */}
+      <div style={{
+        position: 'absolute', right: 4, bottom: 2,
+        fontSize: 6.5, letterSpacing: 0.5, zIndex: 4,
+        color: isNvme ? 'rgba(120,200,255,0.4)' : isEnt ? 'rgba(240,165,0,0.35)' : 'rgba(220,220,230,0.35)',
+        textShadow: '0 0 2px rgba(0,0,0,0.9)',
+        fontFamily: 'var(--mono)',
+      }}>{slot}</div>
+    </button>
+  );
+}
+
+function StatusLamp({ color, label, on = true }: { color: string; label: string; on?: boolean }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+      <span style={{
+        width: 7, height: 7, borderRadius: '50%', display: 'block',
+        background: on ? color : '#0a0a0a',
+        boxShadow: on
+          ? `0 0 6px ${color}, inset 0 0 2px rgba(255,255,255,0.5)`
+          : 'inset 0 0 2px rgba(0,0,0,0.8)',
+      }} />
+      <span style={{ fontSize: 8, color: '#6a6a72', letterSpacing: 1, fontFamily: 'var(--mono)' }}>{label}</span>
+    </div>
+  );
+}
+
+function ChassisRails() {
+  const slotStrip: React.CSSProperties = {
+    position: 'absolute', top: 4, bottom: 4, width: 60,
+    backgroundImage: 'repeating-linear-gradient(90deg, rgba(0,0,0,0.85) 0 2px, transparent 2px 5px)',
+    borderRadius: 1,
+  };
+  return (
+    <div style={{
+      height: 14,
+      background: 'linear-gradient(180deg, #1c1c1f 0%, #0e0e10 50%, #050506 100%)',
+      borderRadius: '6px 6px 0 0',
+      boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.05), inset 0 -1px 0 rgba(0,0,0,0.7)',
+      position: 'relative',
+    }}>
+      <div style={{ ...slotStrip, left: 18 }} />
+      <div style={{ ...slotStrip, right: 18 }} />
+    </div>
+  );
+}
+
+function ChassisFooter() {
+  const slotStrip: React.CSSProperties = {
+    position: 'absolute', top: 4, bottom: 4, width: 60,
+    backgroundImage: 'repeating-linear-gradient(90deg, rgba(0,0,0,0.85) 0 2px, transparent 2px 5px)',
+    borderRadius: 1,
+  };
+  return (
+    <div style={{
+      height: 14,
+      background: 'linear-gradient(0deg, #1c1c1f 0%, #0e0e10 50%, #050506 100%)',
+      borderRadius: '0 0 6px 6px',
+      boxShadow: 'inset 0 -1px 0 rgba(255,255,255,0.04), inset 0 1px 0 rgba(0,0,0,0.7)',
+      position: 'relative',
+    }}>
+      <div style={{ ...slotStrip, left: 18 }} />
+      <div style={{ ...slotStrip, right: 18 }} />
+    </div>
+  );
+}
+
+function RackEar({ side }: { side: 'left' | 'right' }) {
+  return (
+    <div style={{
+      width: 22,
+      background: 'linear-gradient(180deg, #1a1a1c 0%, #0a0a0c 50%, #030304 100%)',
+      borderRadius: side === 'left' ? '6px 0 0 6px' : '0 6px 6px 0',
+      boxShadow: side === 'left'
+        ? 'inset 1px 0 0 rgba(255,255,255,0.05), inset -1px 0 0 rgba(0,0,0,0.6)'
+        : 'inset -1px 0 0 rgba(255,255,255,0.05), inset 1px 0 0 rgba(0,0,0,0.6)',
+      display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'space-between',
+      padding: '14px 0',
+    }}>
+      {[0, 1, 2, 3].map(i => (
+        <div key={i} style={{
+          width: 6, height: 6, borderRadius: '50%',
+          background: 'radial-gradient(circle at 35% 35%, #000 0%, #050505 100%)',
+          boxShadow: 'inset 0 1px 1px rgba(0,0,0,0.95), 0 1px 0 rgba(255,255,255,0.04)',
+        }} />
+      ))}
+    </div>
+  );
+}
+
+const COLS = 4;
+
+const ServerRack: React.FC<ServerRackProps> = ({ drives, onDriveClick, maxSlots = 24 }) => {
+  const hddCount = drives.filter(d => !d.type || d.type === 'hdd').length;
+  const nvmeCount = drives.filter(d => d.type === 'nvme' || d.type === 'nvme-ent').length;
 
   return (
     <div style={{
-      width: '100%',
-      background: 'var(--paper-3)',
-      border: '1px solid var(--rule)',
-      borderRadius: '8px',
-      padding: '12px',
-      boxShadow: '0 4px 24px rgba(0,0,0,0.4)',
+      background: 'linear-gradient(180deg, #0a0a0c 0%, #050506 100%)',
+      borderRadius: 10,
+      boxShadow: '0 1px 0 rgba(255,255,255,0.04), 0 12px 32px rgba(0,0,0,0.7)',
+      border: '1px solid #1a1a1e',
+      overflow: 'hidden',
     }}>
-      {/* Server header */}
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        background: 'var(--paper-2)',
-        borderRadius: '4px',
-        padding: '7px 12px',
-        marginBottom: '10px',
-        border: '1px solid var(--rule)',
-      }}>
-        <div style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-3)', letterSpacing: '0.06em' }}>
-          SRV-R2502 · 4U
-        </div>
+      <ChassisRails />
 
-        <div style={{ display: 'flex', gap: '14px' }}>
-          {[
-            ['PWR', 'var(--ok)', true],
-            ['NET', 'var(--ok)', true],
-            ['HDD', drives.some(d => !d.type || d.type === 'hdd') ? 'var(--ok)' : 'var(--ink-3)', drives.some(d => !d.type || d.type === 'hdd')],
-            ['NVMe', hasNvme ? 'var(--nvme)' : 'var(--ink-3)', hasNvme],
-          ].map(([label, color, active]) => (
-            <div key={label as string} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '3px' }}>
+      <div style={{ display: 'flex', alignItems: 'stretch' }}>
+        <RackEar side="left" />
+
+        <div style={{ flex: 1, padding: '14px 16px' }}>
+          {/* Bezel header */}
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            padding: '8px 14px', marginBottom: 12,
+            background: 'linear-gradient(180deg, #131316 0%, #0a0a0c 100%)',
+            borderRadius: 4,
+            boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -1px 0 rgba(0,0,0,0.7), inset 0 0 0 1px #1a1a1e',
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
               <div style={{
-                width: 6, height: 6, borderRadius: '50%',
-                background: color as string,
-                boxShadow: active ? `0 0 6px ${color}` : 'none',
-              }} />
-              <span style={{ fontFamily: 'var(--mono)', fontSize: '9px', color: 'var(--ink-3)', letterSpacing: '0.05em' }}>{label as string}</span>
+                fontSize: 10, fontWeight: 700, color: '#d6d3e0',
+                padding: '4px 8px',
+                background: 'linear-gradient(180deg, #1c1c20 0%, #0a0a0c 100%)',
+                borderRadius: 2, letterSpacing: 1.5,
+                boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.07), inset 0 -1px 0 rgba(0,0,0,0.7), inset 0 0 0 1px #25252a',
+                fontFamily: 'var(--mono)',
+              }}>RX·CORE</div>
+              <span style={{ fontSize: 11, color: '#a59bc6', letterSpacing: 1, fontFamily: 'var(--mono)' }}>
+                SRV-R2502
+              </span>
             </div>
-          ))}
-        </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+              <StatusLamp color="#1de9b6" label="PWR" />
+              <StatusLamp color="#1de9b6" label="NET" />
+              <StatusLamp color="var(--ok)" label="HDD" on={hddCount > 0} />
+              <StatusLamp color="var(--nvme)" label="NVMe" on={nvmeCount > 0} />
+              <StatusLamp color="var(--warn)" label="ALRT" on={false} />
+            </div>
+          </div>
 
-      </div>
-
-      {/* Drive bays */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-        {Array.from({ length: rows }).map((_, rowIndex) => (
-          <div key={rowIndex} style={{ display: 'grid', gridTemplateColumns: `repeat(${drivesPerRow}, 1fr)`, gap: '6px' }}>
-            {slots.slice(rowIndex * drivesPerRow, (rowIndex + 1) * drivesPerRow).map((slotIndex) => {
-              const drive = drives.find((_, i) => i === slotIndex);
-              const isNvme = drive?.type === 'nvme';
-              const { value, unit } = drive ? formatSize(drive.size) : { value: '', unit: '' };
-
-              const activeBorder = isNvme ? '1px solid rgba(0,212,255,0.45)' : '1px solid var(--rule)';
-              const activeBg = isNvme ? 'rgba(0,10,18,0.95)' : 'var(--paper-2)';
-              const ledColor = isNvme ? 'var(--nvme)' : 'var(--ok)';
-
+          {/* 4×6 bay grid */}
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${COLS}, 1fr)`,
+            gap: 4, padding: 6,
+            background: 'linear-gradient(180deg, #030304 0%, #000 100%)',
+            borderRadius: 4,
+            boxShadow: 'inset 0 2px 4px rgba(0,0,0,0.9), inset 0 0 0 1px #0e0e10',
+          }}>
+            {Array.from({ length: maxSlots }).map((_, i) => {
+              const drive = drives[i];
+              const slot = String(i + 1).padStart(2, '0');
+              if (drive) {
+                const { value, unit } = formatSize(drive.size);
+                return (
+                  <div key={i} style={{ height: 32 }}>
+                    <Caddy
+                      kind={drive.type ?? 'hdd'}
+                      value={value}
+                      unit={unit}
+                      slot={slot}
+                      onClick={() => onDriveClick(drive.id)}
+                    />
+                  </div>
+                );
+              }
               return (
-                <div
-                  key={slotIndex}
-                  onClick={() => drive && onDriveClick(drive.id)}
-                  style={{
-                    position: 'relative',
-                    aspectRatio: '3/1',
-                    borderRadius: '3px',
-                    overflow: 'hidden',
-                    border: drive ? activeBorder : '1px dashed rgba(54,45,89,0.6)',
-                    background: drive ? activeBg : 'var(--paper-3)',
-                    cursor: drive ? 'pointer' : 'default',
-                    transition: 'border-color 0.2s, box-shadow 0.2s',
-                  }}
-                  onMouseEnter={e => {
-                    if (drive) {
-                      const el = e.currentTarget as HTMLDivElement;
-                      el.style.borderColor = isNvme ? 'var(--nvme)' : 'var(--crit)';
-                      el.style.boxShadow = isNvme
-                        ? '0 0 8px rgba(0,212,255,0.3)'
-                        : '0 0 8px rgba(250,127,170,0.25)';
-                    }
-                  }}
-                  onMouseLeave={e => {
-                    if (drive) {
-                      const el = e.currentTarget as HTMLDivElement;
-                      el.style.borderColor = isNvme ? 'rgba(0,212,255,0.45)' : 'var(--rule)';
-                      el.style.boxShadow = 'none';
-                    }
-                  }}
-                >
-                  {drive && (
-                    <div style={{ position: 'absolute', inset: 0, opacity: isNvme ? 0.18 : 0.12 }}>
-                      {isNvme ? (
-                        /* NVMe: circuit trace grid pattern */
-                        <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-                          <defs>
-                            <pattern id={`nv-${drive.id}`} patternUnits="userSpaceOnUse" width="8" height="6">
-                              <rect x="0.5" y="1" width="7" height="4" fill="none" stroke="var(--nvme)" strokeWidth="0.6" rx="0.5" />
-                              <rect x="2" y="2.5" width="4" height="1" fill="var(--nvme)" rx="0.3" />
-                            </pattern>
-                          </defs>
-                          <rect width="100%" height="100%" fill={`url(#nv-${drive.id})`} />
-                        </svg>
-                      ) : (
-                        /* HDD: honeycomb pattern */
-                        <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-                          <defs>
-                            <pattern id={`hc-${drive.id}`} patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="scale(0.5)">
-                              <rect width="100%" height="100%" fill="none" />
-                              <path d="M0,5 L2.5,0 L7.5,0 L10,5 L7.5,10 L2.5,10 Z" fill="var(--ok)" />
-                            </pattern>
-                          </defs>
-                          <rect width="100%" height="100%" fill={`url(#hc-${drive.id})`} />
-                        </svg>
-                      )}
-                    </div>
-                  )}
-
-                  {drive ? (
-                    <>
-                      <div style={{
-                        position: 'absolute', inset: 0,
-                        display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      }}>
-                        <span style={{
-                          fontFamily: 'var(--mono)',
-                          fontSize: '11px',
-                          fontWeight: 500,
-                          color: isNvme ? 'var(--nvme)' : 'var(--ink-2)',
-                          background: isNvme ? 'rgba(0,8,14,0.82)' : 'rgba(21,15,35,0.75)',
-                          padding: '2px 6px',
-                          borderRadius: '2px',
-                          letterSpacing: '0.03em',
-                        }}>
-                          {value}<span style={{ fontSize: '9px', color: isNvme ? 'rgba(0,212,255,0.6)' : 'var(--ink-3)', marginLeft: '1px' }}>{unit}</span>
-                        </span>
-                      </div>
-                      <div style={{ position: 'absolute', top: 3, right: 4 }}>
-                        <div style={{ width: 5, height: 5, borderRadius: '50%', background: ledColor, boxShadow: `0 0 4px ${ledColor}` }} />
-                      </div>
-                      {isNvme && (
-                        <div style={{
-                          position: 'absolute', bottom: 2, left: 4,
-                          fontFamily: 'var(--mono)', fontSize: '7px',
-                          color: 'rgba(0,212,255,0.45)', letterSpacing: '0.06em',
-                        }}>
-                          M.2
-                        </div>
-                      )}
-                    </>
-                  ) : (
-                    <div style={{
-                      position: 'absolute', inset: 0,
-                      display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      opacity: 0.25,
-                    }}>
-                      <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="var(--ink-3)" strokeWidth={1.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                      </svg>
-                    </div>
-                  )}
+                <div key={i} style={{ height: 32 }}>
+                  <EmptyBay label={slot} />
                 </div>
               );
             })}
           </div>
-        ))}
+
+          {/* Rack footer summary */}
+          <div style={{
+            marginTop: 12, padding: '8px 14px',
+            display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+            background: 'linear-gradient(180deg, #131316 0%, #0a0a0c 100%)',
+            borderRadius: 4,
+            boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), inset 0 -1px 0 rgba(0,0,0,0.7), inset 0 0 0 1px #1a1a1e',
+            fontSize: 11,
+          }}>
+            <span style={{ color: '#a59bc6', letterSpacing: 0.5, fontFamily: 'var(--mono)' }}>
+              <span style={{ color: '#e7e3f4' }}>{drives.length}/{maxSlots}</span> bays
+              <span style={{ margin: '0 8px', color: '#3a3245' }}>·</span>
+              <span style={{ color: 'var(--ok)' }}>{hddCount}</span> HDD
+              <span style={{ margin: '0 8px', color: '#3a3245' }}>·</span>
+              <span style={{ color: 'var(--nvme)' }}>{nvmeCount}</span> NVMe
+            </span>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <span style={{ width: 6, height: 6, borderRadius: '50%', display: 'block', background: '#ff9a3e', boxShadow: '0 0 4px #ff9a3e' }} />
+              <span style={{ width: 6, height: 6, borderRadius: '50%', display: 'block', background: 'var(--ok)', boxShadow: '0 0 4px var(--ok)' }} />
+            </div>
+          </div>
+        </div>
+
+        <RackEar side="right" />
       </div>
 
-      {/* Server footer */}
-      <div style={{
-        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-        background: 'var(--paper-2)', borderRadius: '4px', padding: '5px 12px', marginTop: '10px',
-        border: '1px solid var(--rule)',
-      }}>
-        <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: 'var(--ink-3)' }}>
-          {drives.length}/{maxSlots} bays occupied
-          {drives.some(d => !d.type || d.type === 'hdd') && (
-            <span style={{ color: 'var(--ok)', marginLeft: '8px' }}>
-              {drives.filter(d => !d.type || d.type === 'hdd').length} HDD
-            </span>
-          )}
-          {hasNvme && (
-            <span style={{ color: 'var(--nvme)', marginLeft: '8px' }}>
-              {drives.filter(d => d.type === 'nvme').length} NVMe
-            </span>
-          )}
-        </span>
-        <div style={{ display: 'flex', gap: '6px' }}>
-          <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--warn)' }} />
-          <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--ok)' }} />
-        </div>
-      </div>
+      <ChassisFooter />
     </div>
   );
 };

--- a/src/app/VdevRack.tsx
+++ b/src/app/VdevRack.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 interface Drive {
   id: number;
   size: number;
-  type?: 'hdd' | 'nvme';
+  type?: 'hdd' | 'nvme' | 'nvme-ent';
 }
 
 interface VdevRackProps {
@@ -19,103 +19,146 @@ function formatSize(size: number): { value: string; unit: string } {
   return { value: String(size), unit: 'TB' };
 }
 
-const VdevRack: React.FC<VdevRackProps> = ({ drives, type, vdevIndex }) => {
-  const drivesPerRow = 6;
-  const rows = Math.ceil(drives.length / drivesPerRow);
+function meshStyle(tint: 'warm' | 'cool' | 'ember'): React.CSSProperties {
+  const hole = tint === 'cool' ? 'rgba(2,6,12,1)' : tint === 'ember' ? 'rgba(12,6,0,1)' : 'rgba(0,0,0,1)';
+  const ground = tint === 'cool' ? '#1a1c22' : tint === 'ember' ? '#1c1a16' : '#1a1a1d';
+  return {
+    backgroundColor: ground,
+    backgroundImage: `
+      radial-gradient(${hole} 0.9px, transparent 1.2px),
+      radial-gradient(${hole} 0.9px, transparent 1.2px)
+    `,
+    backgroundSize: '4px 4px, 4px 4px',
+    backgroundPosition: '0 0, 2px 2px',
+  };
+}
+
+function MiniCaddy({ size, unit, kind, slot }: { size: string; unit: string; kind: 'hdd' | 'nvme' | 'nvme-ent'; slot: string }) {
+  const isNvme = kind === 'nvme';
+  const isEnt = kind === 'nvme-ent';
+  const ledColor = isNvme ? 'var(--nvme)' : isEnt ? 'var(--nvme-ent)' : 'var(--ok)';
+  const stickerBg = isNvme
+    ? 'linear-gradient(180deg, #07131c 0%, #03080e 100%)'
+    : isEnt
+    ? 'linear-gradient(180deg, #1c0f00 0%, #0e0700 100%)'
+    : 'linear-gradient(180deg, #f3efe2 0%, #d8d3c2 100%)';
+  const stickerColor = isNvme ? 'var(--nvme)' : isEnt ? 'var(--nvme-ent)' : '#1a1a1d';
+  const stickerLabel = isNvme ? 'NVMe' : isEnt ? 'ENT' : 'SAS';
+  const stickerShadow = isNvme
+    ? 'inset 0 0 0 1px rgba(41,225,255,0.5), 0 0 5px rgba(41,225,255,0.18), 0 1px 1px rgba(0,0,0,0.6)'
+    : isEnt
+    ? 'inset 0 0 0 1px rgba(240,165,0,0.5), 0 0 5px rgba(240,165,0,0.18), 0 1px 1px rgba(0,0,0,0.6)'
+    : 'inset 0 1px 0 rgba(255,255,255,0.6), 0 1px 1px rgba(0,0,0,0.6), 0 0 0 1px rgba(0,0,0,0.4)';
+  const stickerTextShadow = isNvme ? '0 0 3px rgba(41,225,255,0.6)' : isEnt ? '0 0 3px rgba(240,165,0,0.6)' : 'none';
 
   return (
     <div style={{
-      width: '100%',
-      background: 'var(--paper-3)',
-      border: '1px solid var(--rule)',
-      borderRadius: '6px',
-      padding: '10px',
+      width: '100%', height: '100%', position: 'relative',
+      borderRadius: 2,
+      background: 'linear-gradient(180deg, #2a2a2e 0%, #1a1a1d 50%, #0e0e10 100%)',
+      boxShadow: `
+        inset 0 1px 0 rgba(255,255,255,0.1),
+        inset 0 -1px 0 rgba(0,0,0,0.7),
+        inset 1px 0 0 rgba(255,255,255,0.05),
+        inset -1px 0 0 rgba(0,0,0,0.5)
+      `,
+      overflow: 'hidden',
     }}>
+      {/* Handle strip with LEDs */}
       <div style={{
-        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-        marginBottom: '8px',
-        paddingBottom: '8px',
-        borderBottom: '1px solid var(--rule)',
+        position: 'absolute', left: 0, top: 0, bottom: 0, width: 14,
+        background: 'linear-gradient(180deg, #1d1d20 0%, #101012 100%)',
+        boxShadow: 'inset -1px 0 0 rgba(0,0,0,0.6)',
       }}>
-        <span style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-2)' }}>
-          vdev {vdevIndex + 1}
-          <span style={{ color: 'var(--accent)', marginLeft: '6px' }}>{type}</span>
-        </span>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-          <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: 'var(--ink-3)' }}>
-            {drives.length} drives
-          </span>
-          <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--ok)', boxShadow: '0 0 4px var(--ok)' }} />
+        <div style={{
+          position: 'absolute', left: '50%', top: 5,
+          transform: 'translateX(-50%)',
+          display: 'flex', flexDirection: 'column', gap: 4,
+        }}>
+          <span style={{
+            width: 3.5, height: 3.5, borderRadius: '50%', display: 'block',
+            background: '#1de9b6',
+            boxShadow: '0 0 4px #1de9b6',
+          }} />
+          <span style={{
+            width: 3.5, height: 3.5, borderRadius: '50%', display: 'block',
+            background: ledColor,
+            boxShadow: `0 0 5px ${ledColor}`,
+            animation: isNvme ? 'caddy-blink-fast 0.9s ease-in-out infinite' : isEnt ? 'caddy-blink-fast 1.2s ease-in-out infinite' : 'caddy-blink 1.6s ease-in-out infinite',
+          }} />
         </div>
       </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-        {Array.from({ length: rows }).map((_, rowIndex) => (
-          <div key={rowIndex} style={{ display: 'grid', gridTemplateColumns: `repeat(${drivesPerRow}, 1fr)`, gap: '4px' }}>
-            {drives.slice(rowIndex * drivesPerRow, (rowIndex + 1) * drivesPerRow).map((drive) => {
-              const isNvme = drive.type === 'nvme';
-              const { value, unit } = formatSize(drive.size);
-              return (
-                <div
-                  key={drive.id}
-                  style={{
-                    position: 'relative',
-                    aspectRatio: '3/1',
-                    borderRadius: '2px',
-                    overflow: 'hidden',
-                    border: isNvme ? '1px solid rgba(0,212,255,0.35)' : '1px solid var(--rule)',
-                    background: isNvme ? 'rgba(0,10,18,0.95)' : 'var(--paper-2)',
-                  }}
-                >
-                  <div style={{ position: 'absolute', inset: 0, opacity: isNvme ? 0.18 : 0.1 }}>
-                    {isNvme ? (
-                      <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-                        <defs>
-                          <pattern id={`nvv-${drive.id}`} patternUnits="userSpaceOnUse" width="8" height="6">
-                            <rect x="0.5" y="1" width="7" height="4" fill="none" stroke="var(--nvme)" strokeWidth="0.6" rx="0.5" />
-                            <rect x="2" y="2.5" width="4" height="1" fill="var(--nvme)" rx="0.3" />
-                          </pattern>
-                        </defs>
-                        <rect width="100%" height="100%" fill={`url(#nvv-${drive.id})`} />
-                      </svg>
-                    ) : (
-                      <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
-                        <defs>
-                          <pattern id={`hcv-${drive.id}`} patternUnits="userSpaceOnUse" width="10" height="10" patternTransform="scale(0.5)">
-                            <rect width="100%" height="100%" fill="none" />
-                            <path d="M0,5 L2.5,0 L7.5,0 L10,5 L7.5,10 L2.5,10 Z" fill="var(--accent)" />
-                          </pattern>
-                        </defs>
-                        <rect width="100%" height="100%" fill={`url(#hcv-${drive.id})`} />
-                      </svg>
-                    )}
-                  </div>
-                  <div style={{
-                    position: 'absolute', inset: 0,
-                    display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  }}>
-                    <span style={{
-                      fontFamily: 'var(--mono)',
-                      fontSize: '10px',
-                      color: isNvme ? 'var(--nvme)' : 'var(--ink-2)',
-                      background: isNvme ? 'rgba(0,8,14,0.82)' : 'rgba(21,15,35,0.75)',
-                      padding: '1px 4px',
-                      borderRadius: '2px',
-                    }}>
-                      {value}<span style={{ fontSize: '8px', color: isNvme ? 'rgba(0,212,255,0.55)' : 'var(--ink-3)' }}>{unit}</span>
-                    </span>
-                  </div>
-                  <div style={{ position: 'absolute', top: 2, right: 3 }}>
-                    <div style={{
-                      width: 4, height: 4, borderRadius: '50%',
-                      background: isNvme ? 'var(--nvme)' : 'var(--ok)',
-                    }} />
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        ))}
+      {/* Sticker */}
+      <div style={{
+        position: 'absolute', left: 17, top: '50%', transform: 'translateY(-50%)',
+        background: stickerBg, color: stickerColor,
+        padding: '2px 4px', fontSize: 7.5, fontWeight: 700, letterSpacing: 0.2,
+        borderRadius: 1, display: 'flex', flexDirection: 'column',
+        alignItems: 'flex-start',
+        boxShadow: stickerShadow, textShadow: stickerTextShadow,
+        zIndex: 3, lineHeight: 1.1, minWidth: 32,
+        fontFamily: 'var(--mono)',
+      }}>
+        <span style={{ fontSize: 6, opacity: isNvme ? 0.85 : 0.7, letterSpacing: 0.5 }}>{stickerLabel}</span>
+        <span style={{ fontSize: 8, fontWeight: 700 }}>
+          {size}<span style={{ fontSize: 5.5, opacity: 0.7, marginLeft: 1 }}>{unit}</span>
+        </span>
+      </div>
+
+      {/* Mesh grille */}
+      <div style={{
+        position: 'absolute', left: 53, right: 4, top: 4, bottom: 4,
+        ...meshStyle(isNvme ? 'cool' : isEnt ? 'ember' : 'warm'),
+        borderRadius: 1.5,
+        boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.65)',
+        overflow: 'hidden',
+      }}>
+        <div style={{ position: 'absolute', inset: 0, boxShadow: 'inset 0 2px 3px rgba(0,0,0,0.55)', pointerEvents: 'none' }} />
+      </div>
+
+      {/* Slot tag */}
+      <div style={{
+        position: 'absolute', right: 4, bottom: 2,
+        fontSize: 6.5, letterSpacing: 0.5, zIndex: 4,
+        color: isNvme ? 'rgba(120,200,255,0.4)' : isEnt ? 'rgba(240,165,0,0.35)' : 'rgba(220,220,230,0.35)',
+        textShadow: '0 0 2px rgba(0,0,0,0.9)',
+        fontFamily: 'var(--mono)',
+      }}>{slot}</div>
+    </div>
+  );
+}
+
+const COLS = 4;
+
+const VdevRack: React.FC<VdevRackProps> = ({ drives }) => {
+  return (
+    <div style={{
+      background: 'linear-gradient(180deg, #080809 0%, #030304 100%)',
+      borderRadius: 6,
+      border: '1px solid #1a1a1e',
+      padding: 6,
+      boxShadow: 'inset 0 1px 3px rgba(0,0,0,0.8), inset 0 0 0 1px #0e0e10',
+    }}>
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${COLS}, 1fr)`,
+        gap: 4,
+      }}>
+        {drives.map((drive, i) => {
+          const { value, unit } = formatSize(drive.size);
+          const slot = String(i + 1).padStart(2, '0');
+          return (
+            <div key={drive.id} style={{ height: 30 }}>
+              <MiniCaddy
+                kind={drive.type ?? 'hdd'}
+                size={value}
+                unit={unit}
+                slot={slot}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,6 +20,7 @@
   --sans:      var(--font-sans, "Rubik"), ui-sans-serif, sans-serif;
   --mono:      var(--font-mono, "JetBrains Mono"), ui-monospace, monospace;
   --nvme:      #00d4ff;
+  --nvme-ent:  #f0a500;
 }
 
 /* ── Base ──────────────────────────────────────── */
@@ -124,6 +125,15 @@ body {
 .drive-btn--nvme:hover {
   background: rgba(0, 212, 255, 0.1);
   border-color: var(--nvme);
+  color: #fff;
+}
+.drive-btn--nvme-ent {
+  border-color: rgba(240, 165, 0, 0.35);
+  color: var(--nvme-ent);
+}
+.drive-btn--nvme-ent:hover {
+  background: rgba(240, 165, 0, 0.1);
+  border-color: var(--nvme-ent);
   color: #fff;
 }
 
@@ -555,6 +565,16 @@ body {
   justify-content: space-between;
   align-items: center;
   margin-top: 12px;
+}
+
+/* ── Caddy LED animations ──────────────────────── */
+@keyframes caddy-blink {
+  0%, 60%, 100% { opacity: 1; }
+  70%, 90% { opacity: 0.25; }
+}
+@keyframes caddy-blink-fast {
+  0%, 50%, 100% { opacity: 1; }
+  60%, 80% { opacity: 0.2; }
 }
 
 /* ── Animations ────────────────────────────────── */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,13 +43,13 @@ const VdevManagerDriveGrid = ({ drives }: { drives: Drive[] }) => (
                 aspectRatio: '3/1',
                 borderRadius: '2px',
                 overflow: 'hidden',
-                border: drive.type === 'nvme' ? '1px solid rgba(0,212,255,0.35)' : '1px solid var(--rule)',
-                background: drive.type === 'nvme' ? 'rgba(0,10,18,0.95)' : 'var(--paper-2)',
+                border: drive.type === 'nvme' ? '1px solid rgba(0,212,255,0.35)' : drive.type === 'nvme-ent' ? '1px solid rgba(240,165,0,0.35)' : '1px solid var(--rule)',
+                background: drive.type === 'nvme' ? 'rgba(0,10,18,0.95)' : drive.type === 'nvme-ent' ? 'rgba(18,10,0,0.95)' : 'var(--paper-2)',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
               }}>
-                <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: drive.type === 'nvme' ? 'var(--nvme)' : 'var(--ink-2)' }}>
+                <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: drive.type === 'nvme' ? 'var(--nvme)' : drive.type === 'nvme-ent' ? 'var(--nvme-ent)' : 'var(--ink-2)' }}>
                   {formatDriveSize(drive.size)}
                 </span>
               </div>
@@ -193,7 +193,7 @@ const RAIDCalculator = () => {
 
   const [driveCapHit, setDriveCapHit] = useState(false);
 
-  const addDrive = (size: number, type: 'hdd' | 'nvme' = 'hdd') => {
+  const addDrive = (size: number, type: 'hdd' | 'nvme' | 'nvme-ent' = 'hdd') => {
     const activeConfig = configs[activeConfigIndex];
     const totalDrives = activeConfig.selectedDrives.length + activeConfig.vdevs.reduce((s, v) => s + v.drives.length, 0);
     if (totalDrives < 24) {
@@ -290,7 +290,7 @@ const RAIDCalculator = () => {
       if (config.selectedDrives.length === 0) return { total: 0, available: 0, protection: 0, formatted: 0, readSpeed: 0, writeSpeed: 0, reliability: 0 };
       const totalRawStorage = config.selectedDrives.reduce((sum, drive) => sum + drive.size, 0);
       const stats = config.fileSystem === 'SnapRAID'
-        ? calcSnapRaid(config.selectedDrives, parseInt(config.raidType.split(' ')[0]))
+        ? calcSnapRaid(config.selectedDrives, parseInt(config.raidType.split(' ')[0]) || 1)
         : calcConfigRaid(config.raidType, config.selectedDrives);
       const overheadPct: { [key: string]: number } = {
         'ZFS': 0.08, 'Unraid': 0.03, 'Synology SHR': 0.085,
@@ -340,7 +340,7 @@ const RAIDCalculator = () => {
 
   const speedBarMax = (config: StorageConfig) => {
     const allDrives = [...config.selectedDrives, ...config.vdevs.flatMap(v => v.drives)];
-    return allDrives.length > 0 && allDrives.every(d => d.type === 'nvme') ? 25000 : 1500;
+    return allDrives.length > 0 && allDrives.every(d => d.type === 'nvme' || d.type === 'nvme-ent') ? 25000 : 1500;
   };
 
   const renderStorageConfig = (config: StorageConfig, index: number, stats: ReturnType<typeof calculateStorage>) => {
@@ -599,12 +599,41 @@ const RAIDCalculator = () => {
       <section style={{ marginBottom: '48px' }} className="rise rise-1">
         <div className="section-label">
           <span>Add Drives</span>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             {(configs[activeConfigIndex].selectedDrives.length > 0 || configs[activeConfigIndex].vdevs.length > 0) && (
               <span style={{ fontFamily: 'var(--mono)', fontSize: '11px', color: 'var(--ink-3)' }}>
                 click a bay to remove
               </span>
             )}
+            {/* Compare mode toggle */}
+            <button
+              onClick={() => setShowComparisonMode(!showComparisonMode)}
+              style={{
+                fontFamily: 'var(--mono)',
+                fontSize: '10px',
+                letterSpacing: '0.1em',
+                textTransform: 'uppercase',
+                padding: '4px 10px',
+                borderRadius: '4px',
+                border: showComparisonMode ? '1px solid var(--ok)' : '1px solid var(--rule)',
+                background: showComparisonMode ? 'rgba(194,239,78,0.07)' : 'transparent',
+                color: showComparisonMode ? 'var(--ok)' : 'var(--ink-2)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+                transition: 'color 0.15s, border-color 0.15s, background 0.15s',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none" style={{ opacity: 0.75 }}>
+                <rect x="0" y="0" width="4" height="10" rx="0.5" fill="currentColor" opacity="0.6"/>
+                <rect x="6" y="0" width="4" height="10" rx="0.5" fill="currentColor" opacity="0.6"/>
+              </svg>
+              {showComparisonMode ? 'Single' : 'Compare'}
+            </button>
+            {/* divider */}
+            <div style={{ width: 1, height: 16, background: 'var(--rule)', opacity: 0.5 }} />
             {/* HDD / NVMe toggle */}
             <div style={{
               display: 'flex', gap: '2px',
@@ -635,12 +664,6 @@ const RAIDCalculator = () => {
                 {size} TB
               </button>
             ))}
-            <button
-              className={`drive-btn ${showComparisonMode ? 'drive-btn--active' : ''}`}
-              onClick={() => setShowComparisonMode(!showComparisonMode)}
-            >
-              {showComparisonMode ? '← Single' : 'Compare →'}
-            </button>
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginBottom: '20px' }}>
@@ -658,10 +681,19 @@ const RAIDCalculator = () => {
             {/* Enterprise / prosumer: ~6% over-provisioned, odd sizes */}
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', alignItems: 'center' }}>
               <span
-                style={{ fontFamily: 'var(--mono)', fontSize: '9px', color: 'var(--ink-3)', textTransform: 'uppercase', letterSpacing: '0.1em', minWidth: '60px', cursor: 'help' }}
+                style={{
+                  fontFamily: 'var(--mono)', fontSize: '9px', color: 'var(--nvme-ent)',
+                  textTransform: 'uppercase', letterSpacing: '0.1em', minWidth: '60px',
+                  cursor: 'help', display: 'flex', alignItems: 'center', gap: '4px',
+                }}
                 title="Over-provisioned: manufacturer reserves ~6% of NAND for wear leveling and garbage collection"
               >
-                Ent. OP
+                <span style={{
+                  fontSize: '7px', fontWeight: 700, background: 'rgba(240,165,0,0.15)',
+                  border: '1px solid rgba(240,165,0,0.4)', borderRadius: '2px',
+                  padding: '0px 3px', lineHeight: '12px', letterSpacing: '0.05em',
+                }}>OP</span>
+                ENT
               </span>
               {nvmeSizesEnterprise.map(size => {
                 const rawNand: Record<number, string> = {
@@ -669,21 +701,13 @@ const RAIDCalculator = () => {
                   1.92: '2 TB', 3.84: '4 TB', 7.68: '8 TB', 15.36: '16 TB',
                 };
                 return (
-                  <button key={size} className="drive-btn drive-btn--nvme" onClick={() => addDrive(size, 'nvme')}
+                  <button key={size} className="drive-btn drive-btn--nvme-ent" onClick={() => addDrive(size, 'nvme-ent')}
                     title={`${formatDriveSize(size)} user-visible · ${rawNand[size]} raw NAND (~6% over-provisioned)`}
                   >
                     {formatDriveSize(size)}
                   </button>
                 );
               })}
-            </div>
-            <div style={{ display: 'flex', gap: '6px' }}>
-              <button
-                className={`drive-btn ${showComparisonMode ? 'drive-btn--active' : ''}`}
-                onClick={() => setShowComparisonMode(!showComparisonMode)}
-              >
-                {showComparisonMode ? '← Single' : 'Compare →'}
-              </button>
             </div>
           </div>
         )}

--- a/src/app/raidCalc.ts
+++ b/src/app/raidCalc.ts
@@ -1,7 +1,7 @@
 export interface Drive {
   id: number;
   size: number;
-  type?: 'hdd' | 'nvme';
+  type?: 'hdd' | 'nvme' | 'nvme-ent';
 }
 
 export interface RaidStats {
@@ -24,7 +24,7 @@ export function formatDriveSize(sizeInTB: number): string {
 
 function getBaseSpeeds(drives: Drive[]): { r: number; w: number } {
   if (drives.length === 0) return { r: BASE_READ_HDD, w: BASE_WRITE_HDD };
-  const nvmeCount = drives.filter(d => d.type === 'nvme').length;
+  const nvmeCount = drives.filter(d => d.type === 'nvme' || d.type === 'nvme-ent').length;
   if (nvmeCount === drives.length) return { r: BASE_READ_NVME, w: BASE_WRITE_NVME };
   if (nvmeCount > 0) return { r: BASE_READ_HDD * 2, w: BASE_WRITE_HDD * 2 };
   return { r: BASE_READ_HDD, w: BASE_WRITE_HDD };


### PR DESCRIPTION
## Summary

- **Dell PowerEdge caddy aesthetic** — full chassis rewrite for `ServerRack` and `VdevRack`: landscape hot-swap caddies with diamond-dot mesh grille, handle strip with dual LEDs, and branded stickers
- **Three distinct drive tiers** in the rack: HDD (cream SAS sticker, green LED), Standard NVMe (cyan sticker + LED, cool mesh), Enterprise NVMe (amber ENT sticker + LED, ember mesh)
- **`nvme-ent` drive type** added throughout — `raidCalc.ts`, `page.tsx`, `ServerRack`, `VdevRack` — enterprise sizes (15.36 TB, 7.68 TB…) now carry their own visual identity
- **Compare mode UX fix** — moved "Compare →" out of the drive-size pill row into the section header as a mode-toggle with a split-panel icon, separated from HDD/NVMe by a divider
- **SnapRAID NaN fix** — `|| 1` fallback on `parseInt` prevents crash when switching FS before `useEffect` normalises `raidType`

## Test plan

- [x] Add HDD drives → cream SAS caddies in rack
- [x] Add Standard NVMe → cyan NVMe caddies
- [x] Add Enterprise NVMe → amber ENT caddies, visually distinct from Standard NVMe
- [x] Drive selector: Standard row cyan, Ent. OP row amber with `OP` badge
- [x] Compare toggle in header (not buried in drive sizes), active state green
- [x] Unraid → SnapRAID switch: no console NaN errors
- [x] All FS calculations correct (ZFS, Unraid, SHR, BTRFS, SnapRAID, Standard)
- [x] Drive cap enforced at 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)