### PR TITLE
fix: sync package.json version to v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storage-planner",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- `v1.2.0` was tagged and released (from PR #54) but `package.json` was never bumped from `1.1.0`
- Without this fix, the pending changeset on PR #55 would try to create `v1.2.0` again — collision
- This PR aligns `package.json` so the next changeset correctly produces `v1.3.0`

## Test plan

- [x] Merge this before PR #55
- [x] Verify PR #55 changeset then targets `1.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)