### PR TITLE
fix: remove hero masthead

### DIFF
--- a/.changeset/remove-hero-masthead.md
+++ b/.changeset/remove-hero-masthead.md
@@ -1,0 +1,5 @@
+---
+"storage-planner": patch
+---
+
+Remove decorative hero masthead from page header.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -588,13 +588,6 @@ const RAIDCalculator = () => {
 
   return (
     <div className="page">
-      {/* Masthead */}
-      <header className="masthead rise">
-        <div className="eyebrow">Storage Planner</div>
-        <h1>Plan Your Array.</h1>
-        <p className="sub">Visualize RAID configurations, estimate usable capacity and performance.</p>
-      </header>
-
       {/* Step 1: Select drives */}
       <section style={{ marginBottom: '48px' }} className="rise rise-1">
         <div className="section-label">


### PR DESCRIPTION
## Summary
- Removes decorative hero header ("Plan Your Array." + subtitle) from the top of the page
- App now starts directly at the "Add Drives" section, reducing unnecessary scrolling

## Test plan
- [x] Page loads directly at drive selection UI with no missing elements
- [x] Footer still renders correctly
- [x] All existing functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)